### PR TITLE
cache jvm tools, particularly zinc

### DIFF
--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -12,3 +12,7 @@ options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 # and get oomkilled from launching too many workers with too much total memory
 # overhead.
 worker_count: 4
+
+[cache.bootstrap.bootstrap-jvm-tools]
+write_to:  [ "~/.cache/pants/tools/jvm" ]
+read_from: [ "~/.cache/pants/tools/jvm" ]


### PR DESCRIPTION
Speed up CI by including some JVM tools in the cache folder. In particular, this should shave off a minute that is currently spent just building the zinc tool every time.
