### PR TITLE
upgrade to pants 1.0

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -1,12 +1,5 @@
 [DEFAULT]
-pants_version: 0.0.71
-
-[jvm]
-jdk_paths = {
-    'macos': [
-      '/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk',
-    ]
-  }
+pants_version: 1.0.0
 
 [jvm-platform]
 default_platform: java8


### PR DESCRIPTION
Pants 1.0 complains about the `[jvm] jdk_paths` setting in `pants.ini`. So I also removed that bit from that file to make the build happy without warnings. I think it wasn't really needed (at least not in my current dev environment).
