### PR TITLE
rename tuple types

### DIFF
--- a/src/com/bluegosling/apt/reflect/ArClass.java
+++ b/src/com/bluegosling/apt/reflect/ArClass.java
@@ -264,7 +264,7 @@ public abstract class ArClass implements ArAnnotatedElement, ArGenericDeclaratio
       // different Elements means different compile context, so we should re-query
       try {
          ArClass javaLangObject = forName(Object.class.getCanonicalName());
-         memoizedJavaLangObject = Pair.create(javaLangObject, elements());
+         memoizedJavaLangObject = Pair.of(javaLangObject, elements());
          return javaLangObject;
       } catch (ClassNotFoundException e) {
          // really should never happen
@@ -1377,7 +1377,7 @@ public abstract class ArClass implements ArAnnotatedElement, ArGenericDeclaratio
          typeMirrorMap.put(int.class, types().getPrimitiveType(TypeKind.INT));
          typeMirrorMap.put(long.class, types().getPrimitiveType(TypeKind.LONG));
          typeMirrorMap.put(short.class, types().getPrimitiveType(TypeKind.SHORT));
-         memoizedTypeMirrorMap = Pair.create(typeMirrorMap, types());
+         memoizedTypeMirrorMap = Pair.of(typeMirrorMap, types());
          return typeMirrorMap;
       }
       

--- a/src/com/bluegosling/buildgen/SourceDependencyAnalyzer.java
+++ b/src/com/bluegosling/buildgen/SourceDependencyAnalyzer.java
@@ -1189,7 +1189,7 @@ public class SourceDependencyAnalyzer {
       for (List<PackageDirectory> cycle : results.getPackageCycles()) {
          System.out.println("Found cycle: " + cycle);
          for (int i = 1; i < cycle.size(); i++) {
-            relationships.add(Pair.create(cycle.get(i - 1), cycle.get(i)));
+            relationships.add(Pair.of(cycle.get(i - 1), cycle.get(i)));
          }
       }
       // and show the dependencies that caused the cycles

--- a/src/com/bluegosling/collections/concurrent/PersistentListBackedConcurrentList.java
+++ b/src/com/bluegosling/collections/concurrent/PersistentListBackedConcurrentList.java
@@ -607,7 +607,7 @@ public abstract class PersistentListBackedConcurrentList<E> implements Concurren
             int start = from > l.size() ? l.size() : from;
             int end = to > l.size() ? l.size() : to;
             List<E> subList = l.subList(start, end);
-            memoized = Pair.create(l, subList);
+            memoized = Pair.of(l, subList);
             return subList;
          }
          

--- a/src/com/bluegosling/collections/lists/UnrolledLinkedList.java
+++ b/src/com/bluegosling/collections/lists/UnrolledLinkedList.java
@@ -142,7 +142,7 @@ public class UnrolledLinkedList<E> extends AbstractSequentialList<E> implements 
             node = node.next;
          }
       }
-      return Pair.create(node, offset);
+      return Pair.of(node, offset);
    }
    
    E remove(Node<E> node, int offset) {

--- a/src/com/bluegosling/collections/tries/AbstractCompositeTrie.java
+++ b/src/com/bluegosling/collections/tries/AbstractCompositeTrie.java
@@ -4,7 +4,7 @@ import com.bluegosling.collections.CollectionUtils;
 import com.bluegosling.collections.MapUtils;
 import com.bluegosling.collections.MoreIterables;
 import com.bluegosling.possible.Reference;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 import com.google.common.collect.Iterables;
 
 import java.util.AbstractCollection;
@@ -306,7 +306,7 @@ abstract class AbstractCompositeTrie<K, C, V, N extends AbstractTrie.Node<C, K, 
       
       @Override
       public void putAll(Map<? extends K, ? extends V> m) {
-         List<Trio<Iterable<C>, K, V>> entries = new ArrayList<>(m.size());
+         List<Triple<Iterable<C>, K, V>> entries = new ArrayList<>(m.size());
          // first pass, check all prefixes and create list of new entries w/ suffixes
          for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
             K key = entry.getKey();
@@ -315,10 +315,10 @@ abstract class AbstractCompositeTrie<K, C, V, N extends AbstractTrie.Node<C, K, 
                throw new IllegalArgumentException(
                      "Key, " + key + ", does not have prefix " + CollectionUtils.toString(prefix));
             }
-            entries.add(Trio.create(k, key, entry.getValue()));
+            entries.add(Triple.of(k, key, entry.getValue()));
          }
          // they've all been checked for correct prefix; add 'em
-         for (Trio<Iterable<C>, K, V> entry : entries) {
+         for (Triple<Iterable<C>, K, V> entry : entries) {
             put(entry.getFirst(), entry.getSecond(), entry.getThird());
          }
       }

--- a/src/com/bluegosling/collections/tries/AbstractNavigableCompositeTrie.java
+++ b/src/com/bluegosling/collections/tries/AbstractNavigableCompositeTrie.java
@@ -7,7 +7,7 @@ import com.bluegosling.collections.DescendingSet;
 import com.bluegosling.collections.MapUtils;
 import com.bluegosling.collections.MoreIterables;
 import com.bluegosling.possible.Reference;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 import com.google.common.collect.Iterables;
 
 import java.util.AbstractCollection;
@@ -449,7 +449,7 @@ abstract class AbstractNavigableCompositeTrie<K, C, V, N extends AbstractNavigab
       
       @Override
       public void putAll(Map<? extends K, ? extends V> m) {
-         List<Trio<Iterable<C>, K, V>> entries = new ArrayList<>(m.size());
+         List<Triple<Iterable<C>, K, V>> entries = new ArrayList<>(m.size());
          // first pass, check all prefixes and create list of new entries w/ suffixes
          for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
             K key = entry.getKey();
@@ -458,10 +458,10 @@ abstract class AbstractNavigableCompositeTrie<K, C, V, N extends AbstractNavigab
                throw new IllegalArgumentException(
                      "Key, " + key + ", does not have prefix " + CollectionUtils.toString(prefix));
             }
-            entries.add(Trio.create(k, key, entry.getValue()));
+            entries.add(Triple.of(k, key, entry.getValue()));
          }
          // they've all been checked for correct prefix; add 'em
-         for (Trio<Iterable<C>, K, V> entry : entries) {
+         for (Triple<Iterable<C>, K, V> entry : entries) {
             put(entry.getFirst(), entry.getSecond(), entry.getThird());
          }
       }

--- a/src/com/bluegosling/collections/tries/AbstractNavigableTrie.java
+++ b/src/com/bluegosling/collections/tries/AbstractNavigableTrie.java
@@ -262,7 +262,7 @@ abstract class AbstractNavigableTrie<K, X, V, N extends AbstractNavigableTrie.Na
                // need it...
                path = new ArrayDeque<>();
             }
-            path.push(Pair.create(node, k));
+            path.push(Pair.of(node, k));
          }
          node = entry.getValue();
          assert node != null;
@@ -367,7 +367,7 @@ abstract class AbstractNavigableTrie<K, X, V, N extends AbstractNavigableTrie.Na
                // need it...
                path = new ArrayDeque<>();
             }
-            path.push(Pair.create(node, k));
+            path.push(Pair.of(node, k));
          }
          node = entry.getValue();
       }

--- a/src/com/bluegosling/concurrent/atoms/Transaction.java
+++ b/src/com/bluegosling/concurrent/atoms/Transaction.java
@@ -8,7 +8,7 @@ import com.bluegosling.concurrent.locks.HierarchicalLock.AcquiredLock;
 import com.bluegosling.concurrent.locks.HierarchicalLock.ExclusiveLock;
 import com.bluegosling.concurrent.locks.HierarchicalLock.SharedLock;
 import com.bluegosling.tuples.Pair;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1002,7 +1002,7 @@ public class Transaction {
             atom.validate(value);
          }
          value = commute.getFirst().apply(value);
-         pendingFutures.add(Pair.create(commute.getSecond(), value));
+         pendingFutures.add(Pair.of(commute.getSecond(), value));
       }
       setAtom(atom, value, true);
    }
@@ -1079,7 +1079,7 @@ public class Transaction {
             }
          }
          
-         List<Trio<TransactionalAtom<Object>, Object, Object>> notifications = new ArrayList<>();
+         List<Triple<TransactionalAtom<Object>, Object, Object>> notifications = new ArrayList<>();
          
          long newVersion = pinNewVersion();
          try {
@@ -1094,7 +1094,7 @@ public class Transaction {
                   if (info.isDirty() && markedAtoms.remove(atom)) {
                      Object newValue = info.getValue();
                      Object oldValue = atom.addValue(info.getValue(), newVersion, oldestVersion);
-                     notifications.add(Trio.create(atom, oldValue, newValue));
+                     notifications.add(Triple.of(atom, oldValue, newValue));
                      atom.unmark(); // "release" the atom eagerly
                   }
                }
@@ -1119,7 +1119,7 @@ public class Transaction {
          processAsyncActions(savepoint);
          
          // send notifications
-         for (Trio<TransactionalAtom<Object>, Object, Object> notification : notifications) {
+         for (Triple<TransactionalAtom<Object>, Object, Object> notification : notifications) {
             notification.getFirst().notify(notification.getSecond(), notification.getThird());
          }
          
@@ -1428,7 +1428,7 @@ public class Transaction {
          acquireLock(atom, info, LockState.LOCKED_EXCLUSIVE, false);
       }
       info.commutes.add(Pair.<Function<? super T, ? extends T>, SettableFluentFuture<T>>
-            create(function, future));
+            of(function, future));
       return future;
    }
    
@@ -1442,7 +1442,7 @@ public class Transaction {
    <T> void enqueueAsynchronousAction(AsynchronousAtom<T> atom,
          RunnableFluentFuture<T> runnable) {
       Pair<AsynchronousAtom<?>, RunnableFluentFuture<?>> pair =
-            Pair.<AsynchronousAtom<?>, RunnableFluentFuture<?>>create(atom, runnable); 
+            Pair.<AsynchronousAtom<?>, RunnableFluentFuture<?>>of(atom, runnable); 
       savepoint.asyncActions.add(pair);
    }
    

--- a/src/com/bluegosling/concurrent/executors/ContextPropagatingExecutor.java
+++ b/src/com/bluegosling/concurrent/executors/ContextPropagatingExecutor.java
@@ -38,7 +38,7 @@ public class ContextPropagatingExecutor extends WrappingExecutor {
       for (ContextPropagator<?> p : propagators) {
          @SuppressWarnings("unchecked")
          ContextPropagator<Object> pObj = (ContextPropagator<Object>) p;
-         captured.add(Pair.create(pObj, pObj.capture()));
+         captured.add(Pair.of(pObj, pObj.capture()));
       }
       
       return () -> {
@@ -46,7 +46,7 @@ public class ContextPropagatingExecutor extends WrappingExecutor {
          List<Pair<ContextPropagator<Object>, Object>> installed = new ArrayList<>(captured.size());
          try {
             for (Pair<ContextPropagator<Object>, Object> p : captured) {
-               installed.add(Pair.create(p.getFirst(), p.getFirst().install(p.getSecond())));
+               installed.add(Pair.of(p.getFirst(), p.getFirst().install(p.getSecond())));
             }
             // run the task
             r.run();

--- a/src/com/bluegosling/concurrent/executors/ContextPropagatingExecutorService.java
+++ b/src/com/bluegosling/concurrent/executors/ContextPropagatingExecutorService.java
@@ -40,7 +40,7 @@ public class ContextPropagatingExecutorService extends WrappingExecutorService {
       for (ContextPropagator<?> p : propagators) {
          @SuppressWarnings("unchecked")
          ContextPropagator<Object> pObj = (ContextPropagator<Object>) p;
-         captured.add(Pair.create(pObj, pObj.capture()));
+         captured.add(Pair.of(pObj, pObj.capture()));
       }
       
       return () -> {
@@ -48,7 +48,7 @@ public class ContextPropagatingExecutorService extends WrappingExecutorService {
          List<Pair<ContextPropagator<Object>, Object>> installed = new ArrayList<>(captured.size());
          try {
             for (Pair<ContextPropagator<Object>, Object> p : captured) {
-               installed.add(Pair.create(p.getFirst(), p.getFirst().install(p.getSecond())));
+               installed.add(Pair.of(p.getFirst(), p.getFirst().install(p.getSecond())));
             }
             // run the task
             return c.call();

--- a/src/com/bluegosling/concurrent/extras/FutureTuples.java
+++ b/src/com/bluegosling/concurrent/extras/FutureTuples.java
@@ -4,53 +4,53 @@ import com.bluegosling.concurrent.fluent.CombiningFluentFuture;
 import com.bluegosling.concurrent.fluent.FluentFuture;
 import com.bluegosling.tuples.NTuple;
 import com.bluegosling.tuples.Pair;
-import com.bluegosling.tuples.Quartet;
-import com.bluegosling.tuples.Quintet;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Quadruple;
+import com.bluegosling.tuples.Quintuple;
+import com.bluegosling.tuples.Triple;
 import com.bluegosling.tuples.Tuple;
 import com.bluegosling.tuples.Tuples;
-import com.bluegosling.tuples.Unit;
+import com.bluegosling.tuples.Single;
 
 import java.util.Arrays;
 
 //TODO: javadoc
 //TODO: tests
 public class FutureTuples {
-   public static <T> FluentFuture<Unit<T>> asUnit(FluentFuture<? extends T> future) {
-      return future.map((o) -> Unit.create(o));
+   public static <T> FluentFuture<Single<T>> asSingle(FluentFuture<? extends T> future) {
+      return future.map((o) -> Single.of(o));
    }
    
    public static <T, U> FluentFuture<Pair<T, U>> asPair(FluentFuture<? extends T> futureT,
          FluentFuture<? extends U> futureU) {
-      return futureT.combineWith(futureU, (t, u) -> Pair.<T, U>create(t, u));
+      return futureT.combineWith(futureU, (t, u) -> Pair.<T, U>of(t, u));
    }
 
-   public static <T, U, V> FluentFuture<Trio<T, U, V>> asTrio(
+   public static <T, U, V> FluentFuture<Triple<T, U, V>> asTriple(
          FluentFuture<? extends T> futureT, FluentFuture<? extends U> futureU,
          FluentFuture<? extends V> futureV) {
-      return futureT.combineWith(futureU, futureV, (t, u, v) -> Trio.<T, U, V>create(t, u, v));
+      return futureT.combineWith(futureU, futureV, (t, u, v) -> Triple.<T, U, V>of(t, u, v));
    }
 
-   public static <T, U, V, W> FluentFuture<Quartet<T, U, V, W>> asQuartet(
+   public static <T, U, V, W> FluentFuture<Quadruple<T, U, V, W>> asQuadruple(
          FluentFuture<? extends T> futureT, FluentFuture<? extends U> futureU,
          FluentFuture<? extends V> futureV, FluentFuture<? extends W> futureW) {
-      return new CombiningFluentFuture<Quartet<T,U, V, W>>(
+      return new CombiningFluentFuture<Quadruple<T,U, V, W>>(
             Arrays.asList(futureT, futureU, futureV, futureW)) {
-         @Override protected Quartet<T, U, V, W> computeValue() {
-            return Quartet.create(futureT.getResult(), futureU.getResult(),
+         @Override protected Quadruple<T, U, V, W> computeValue() {
+            return Quadruple.of(futureT.getResult(), futureU.getResult(),
                   futureV.getResult(), futureW.getResult());
          }
       };
    }
 
-   public static <T, U, V, W, X> FluentFuture<Quintet<T, U, V, W, X>> asQuintet(
+   public static <T, U, V, W, X> FluentFuture<Quintuple<T, U, V, W, X>> asQuintuple(
          FluentFuture<? extends T> futureT, FluentFuture<? extends U> futureU,
          FluentFuture<? extends V> futureV, FluentFuture<? extends W> futureW,
          FluentFuture<? extends X> futureX) {
-      return new CombiningFluentFuture<Quintet<T,U, V, W, X>>(
+      return new CombiningFluentFuture<Quintuple<T,U, V, W, X>>(
             Arrays.asList(futureT, futureU, futureV, futureW, futureX)) {
-         @Override protected Quintet<T, U, V, W, X> computeValue() {
-            return Quintet.create(futureT.getResult(), futureU.getResult(), futureV.getResult(),
+         @Override protected Quintuple<T, U, V, W, X> computeValue() {
+            return Quintuple.of(futureT.getResult(), futureU.getResult(), futureV.getResult(),
                   futureW.getResult(), futureX.getResult());
          }
       };

--- a/src/com/bluegosling/concurrent/fluent/FluentFutures.java
+++ b/src/com/bluegosling/concurrent/fluent/FluentFutures.java
@@ -1537,7 +1537,7 @@ final class FluentFutures {
       
       private static <T, U> FluentFuture<Pair<T, U>> combine(FluentFuture<? extends T> futureT,
             FluentFuture<? extends U> futureU) {
-         return futureT.combineWith(futureU, (t, u) -> Pair.<T, U>create(t, u));
+         return futureT.combineWith(futureU, (t, u) -> Pair.<T, U>of(t, u));
       }
       
       /**

--- a/src/com/bluegosling/streams/FluentStream.java
+++ b/src/com/bluegosling/streams/FluentStream.java
@@ -17,7 +17,7 @@ import com.bluegosling.collections.MoreSpliterators;
 import com.bluegosling.collections.MoreStreams;
 import com.bluegosling.function.TriFunction;
 import com.bluegosling.tuples.Pair;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 /**
  * A fluent stream is a {@link Stream} that provides extra operations, including extensibility in
@@ -240,7 +240,7 @@ public interface FluentStream<T> extends Stream<T> {
     */
    default Pair<FluentStream<T>, FluentStream<T>> fork() {
       Supplier<FluentStream<T>> forks = fork(2);
-      return Pair.create(forks.get(), forks.get());
+      return Pair.of(forks.get(), forks.get());
    }
 
    /**
@@ -252,7 +252,7 @@ public interface FluentStream<T> extends Stream<T> {
     */
    default Pair<FluentStream<T>, FluentStream<T>> partition(Predicate<? super T> criteria) {
       Pair<FluentStream<T>, FluentStream<T>> forked = fork();
-      return Pair.create(forked.getFirst().filter(criteria),
+      return Pair.of(forked.getFirst().filter(criteria),
             forked.getSecond().filter(criteria.negate()));
    }
 
@@ -308,7 +308,7 @@ public interface FluentStream<T> extends Stream<T> {
     * stream.join(other,
     *     keyExtractor1, valueExtractor1,
     *     keyExtractor2, valueExtractor2,
-    *     Trio::create);
+    *     Triple::of);
     * </pre>
     * 
     * @param other a stream
@@ -320,15 +320,15 @@ public interface FluentStream<T> extends Stream<T> {
     *       stream
     * @return a stream that is the joined result of this stream and the given stream
     */
-   default <K, U, V, W> FluentStream<Trio<K, Collection<V>, Collection<W>>> join(
+   default <K, U, V, W> FluentStream<Triple<K, Collection<V>, Collection<W>>> join(
          Stream<? extends U> other,
          Function<? super T, ? extends K> keyExtractor1,
          Function<? super T, ? extends V> valueExtractor1,
          Function<? super U, ? extends K> keyExtractor2,
          Function<? super U, ? extends W> valueExtractor2) {
-      return this.<K, U, V, W, Trio<K, Collection<V>, Collection<W>>>
+      return this.<K, U, V, W, Triple<K, Collection<V>, Collection<W>>>
             join(other, keyExtractor1, valueExtractor1, keyExtractor2, valueExtractor2,
-                  Trio::create);
+                  Triple::of);
    }
 
    /**
@@ -337,7 +337,7 @@ public interface FluentStream<T> extends Stream<T> {
     * stream.join(other,
     *     keyExtractor1, Function.identity(),
     *     keyExtractor2, Function.identity(),
-    *     Trio::create);
+    *     Triple::of);
     * </pre>
     * 
     * @param other a stream
@@ -346,7 +346,7 @@ public interface FluentStream<T> extends Stream<T> {
     *       stream
     * @return a stream that is the joined result of this stream and the given stream
     */
-   default <K, U> FluentStream<Trio<K, Collection<T>, Collection<U>>> join(
+   default <K, U> FluentStream<Triple<K, Collection<T>, Collection<U>>> join(
          Stream<? extends U> other, Function<? super T, ? extends K> keyExtractor1,
          Function<? super U, ? extends K> keyExtractor2) {
       return join(other, keyExtractor1, Function.identity(), keyExtractor2, Function.identity());

--- a/src/com/bluegosling/tuples/Empty.java
+++ b/src/com/bluegosling/tuples/Empty.java
@@ -49,12 +49,12 @@ public final class Empty implements Tuple, Serializable {
    }
 
    @Override
-   public <T> Unit<T> add(T t) {
-      return Unit.create(t);
+   public <T> Single<T> add(T t) {
+      return Single.of(t);
    }
 
    @Override
-   public <T> Unit<T> insertFirst(T t) {
+   public <T> Single<T> insertFirst(T t) {
       return add(t);
    }
 

--- a/src/com/bluegosling/tuples/NTuple.java
+++ b/src/com/bluegosling/tuples/NTuple.java
@@ -72,7 +72,7 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
    
    /**
     * Creates a new tuple. The tuple must have at least 6 items (otherwise, it would be a
-    * {@link Quintet}).
+    * {@link Quintuple}).
     * 
     * @param a the first item
     * @param b the second item
@@ -185,13 +185,13 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * {@inheritDoc}
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     */
    @Override
    public Ops5<B, C, D, E, ?> removeFirst() {
       if (array.length == 6) {
-         return Quintet.create(b, c, d, e, array[5]);
+         return Quintuple.of(b, c, d, e, array[5]);
       } else {
          return new NTuple<B, C, D, E, Object>(removeItem(array, 0));
       }
@@ -201,13 +201,13 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * {@inheritDoc}
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     */
    @Override
    public Ops5<A, C, D, E, ?> removeSecond() {
       if (array.length == 6) {
-         return Quintet.create(a, c, d, e, array[5]);
+         return Quintuple.of(a, c, d, e, array[5]);
       } else {
          return new NTuple<A, C, D, E, Object>(removeItem(array, 1));
       }
@@ -217,13 +217,13 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * {@inheritDoc}
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     */
    @Override
    public Ops5<A, B, D, E, ?> removeThird() {
       if (array.length == 6) {
-         return Quintet.create(a, b, d, e, array[5]);
+         return Quintuple.of(a, b, d, e, array[5]);
       } else {
          return new NTuple<A, B, D, E, Object>(removeItem(array, 2));
       }
@@ -233,13 +233,13 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * {@inheritDoc}
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     */
    @Override
    public Ops5<A, B, C, E, ?> removeFourth() {
       if (array.length == 6) {
-         return Quintet.create(a, b, c, e, array[5]);
+         return Quintuple.of(a, b, c, e, array[5]);
       } else {
          return new NTuple<A, B, C, E, Object>(removeItem(array, 3));
       }
@@ -249,13 +249,13 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * {@inheritDoc}
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     */
    @Override
    public Ops5<A, B, C, D, ?> removeFifth() {
       if (array.length == 6) {
-         return Quintet.create(a, b, c, d, array[5]);
+         return Quintuple.of(a, b, c, d, array[5]);
       } else {
          return new NTuple<A, B, C, D, Object>(removeItem(array, 4));
       }
@@ -410,7 +410,7 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
     * calling {@link #removeFirst()}.
     * 
     * <p>If this tuple has exactly six elements, then the returned tuple will have five elements and
-    * thus be an instance of {@link Quintet}. If this tuple has more than six elements, then the
+    * thus be an instance of {@link Quintuple}. If this tuple has more than six elements, then the
     * returned tuple will also be an {@link NTuple}.
     *
     * @param index the zero-based index of the item to remove
@@ -424,7 +424,7 @@ public final class NTuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, S
       Object newArray[] = removeItem(array, index);
       if (array.length == 6) {
          assert newArray.length == 5;
-         return Quintet.create(newArray[0], newArray[1], newArray[2], newArray[3], newArray[4]);
+         return Quintuple.of(newArray[0], newArray[1], newArray[2], newArray[3], newArray[4]);
       } else {
          return new NTuple<B, C, D, E, Object>(newArray);
       }

--- a/src/com/bluegosling/tuples/Pair.java
+++ b/src/com/bluegosling/tuples/Pair.java
@@ -55,7 +55,7 @@ public final class Pair<A, B> implements Tuple.Ops2<A, B>, Serializable {
          t.add(pair.getFirst());
          u.add(pair.getSecond());
       }
-      return create(Collections.unmodifiableList(t), Collections.unmodifiableList(u));
+      return of(Collections.unmodifiableList(t), Collections.unmodifiableList(u));
    }
 
    /**
@@ -92,7 +92,7 @@ public final class Pair<A, B> implements Tuple.Ops2<A, B>, Serializable {
       Iterator<T> tIter = t.iterator();
       Iterator<U> uIter = u.iterator();
       while (tIter.hasNext() && uIter.hasNext()) {
-         list.add(create(tIter.next(), uIter.next()));
+         list.add(of(tIter.next(), uIter.next()));
       }
       if (tIter.hasNext() || uIter.hasNext()) {
          // size changed since check above such that two collections differ
@@ -116,7 +116,7 @@ public final class Pair<A, B> implements Tuple.Ops2<A, B>, Serializable {
     * @param b the second item in the pair
     * @return a new pair
     */
-   public static <A, B> Pair<A, B> create(A a, B b) {
+   public static <A, B> Pair<A, B> of(A a, B b) {
       return new Pair<A, B>(a, b);
    }
 
@@ -153,57 +153,57 @@ public final class Pair<A, B> implements Tuple.Ops2<A, B>, Serializable {
 
    @Override
    public <T> Pair<T, B> setFirst(T t) {
-      return Pair.create(t, b);
+      return Pair.of(t, b);
    }
 
    @Override
    public <T> Pair<A, T> setSecond(T t) {
-      return Pair.create(a, t);
+      return Pair.of(a, t);
    }
 
    @Override
-   public Unit<B> removeFirst() {
-      return Unit.create(b);
+   public Single<B> removeFirst() {
+      return Single.of(b);
    }
 
    @Override
-   public Unit<A> removeSecond() {
-      return Unit.create(a);
+   public Single<A> removeSecond() {
+      return Single.of(a);
    }
 
    @Override
-   public <T> Trio<A, B, T> add(T t) {
-      return Trio.create(a, b, t);
+   public <T> Triple<A, B, T> add(T t) {
+      return Triple.of(a, b, t);
    }
 
    @Override
-   public <T> Trio<T, A, B> insertFirst(T t) {
-      return Trio.create(t, a, b);
+   public <T> Triple<T, A, B> insertFirst(T t) {
+      return Triple.of(t, a, b);
    }
 
    @Override
-   public <T> Trio<A, T, B> insertSecond(T t) {
-      return Trio.create(a, t, b);
+   public <T> Triple<A, T, B> insertSecond(T t) {
+      return Triple.of(a, t, b);
    }
 
    @Override
-   public <T> Trio<A, B, T> insertThird(T t) {
+   public <T> Triple<A, B, T> insertThird(T t) {
       return add(t);
    }
 
    @Override
    public <T> Pair<T, T> transformAll(Function<Object, ? extends T> function) {
-      return Pair.<T, T>create(function.apply(a), function.apply(b));
+      return Pair.<T, T>of(function.apply(a), function.apply(b));
    }
 
    @Override
    public <T> Pair<T, B> transformFirst(Function<? super A, ? extends T> function) {
-      return Pair.<T, B>create(function.apply(a), b);
+      return Pair.<T, B>of(function.apply(a), b);
    }
 
    @Override
    public <T> Pair<A, T> transformSecond(Function<? super B, ? extends T> function) {
-      return Pair.<A, T>create(a, function.apply(b));
+      return Pair.<A, T>of(a, function.apply(b));
    }
    
    /**
@@ -228,7 +228,7 @@ public final class Pair<A, B> implements Tuple.Ops2<A, B>, Serializable {
    
    // TODO: doc, test
    public Pair<B, A> swap() {
-      return Pair.create(b, a);
+      return Pair.of(b, a);
    }
    
    @Override

--- a/src/com/bluegosling/tuples/Quadruple.java
+++ b/src/com/bluegosling/tuples/Quadruple.java
@@ -21,7 +21,7 @@ import com.bluegosling.util.ValueType;
  * @param <D> the type of the fourth item
  */
 @ValueType
-public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serializable {
+public final class Quadruple<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serializable {
 
    private static final long serialVersionUID = -4005223210115823097L;
 
@@ -35,7 +35,7 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
     * @return a list view of the specified quartet
     */
    @SuppressWarnings("unchecked") // thanks to type bounds, we know the cast is safe
-   public static <T> List<T> asTypedList(Quartet<? extends T, ? extends T, ? extends T, ? extends T> quartet) {
+   public static <T> List<T> asTypedList(Quadruple<? extends T, ? extends T, ? extends T, ? extends T> quartet) {
       return (List<T>) quartet.asList();
    }
 
@@ -48,19 +48,19 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
     * @param quartets a collection of quartet
     * @return a quartet of lists whose values were extracted from the collection of quartets
     */
-   public static <T, U, V, W> Quartet<List<T>, List<U>, List<V>, List<W>> separate(
-         Collection<Quartet<T, U, V, W>> quartets) {
+   public static <T, U, V, W> Quadruple<List<T>, List<U>, List<V>, List<W>> separate(
+         Collection<Quadruple<T, U, V, W>> quartets) {
       List<T> t = new ArrayList<T>(quartets.size());
       List<U> u = new ArrayList<U>(quartets.size());
       List<V> v = new ArrayList<V>(quartets.size());
       List<W> w = new ArrayList<W>(quartets.size());
-      for (Quartet<T, U, V, W> quartet : quartets) {
+      for (Quadruple<T, U, V, W> quartet : quartets) {
          t.add(quartet.getFirst());
          u.add(quartet.getSecond());
          v.add(quartet.getThird());
          w.add(quartet.getFourth());
       }
-      return create(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
+      return of(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
             Collections.unmodifiableList(v), Collections.unmodifiableList(w));
    }
 
@@ -74,8 +74,8 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
     * @return a list of quartets, each one representing corresponding values from the collections
     * @throws IllegalArgumentException if any collection has a different size than the others
     */   
-   public static <T, U, V, W> List<Quartet<T, U, V, W>> combine(
-         Quartet<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>,
+   public static <T, U, V, W> List<Quadruple<T, U, V, W>> combine(
+         Quadruple<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>,
                ? extends Collection<W>> quartet) {
       return combine(quartet.getFirst(), quartet.getSecond(), quartet.getThird(),
             quartet.getFourth());
@@ -94,18 +94,18 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
     * @return a list of quartets, each one representing corresponding values from the collections
     * @throws IllegalArgumentException if any collection has a different size than the others
     */
-   public static <T, U, V, W> List<Quartet<T, U, V, W>> combine(Collection<T> t, Collection<U> u,
+   public static <T, U, V, W> List<Quadruple<T, U, V, W>> combine(Collection<T> t, Collection<U> u,
          Collection<V> v, Collection<W> w) {
       if (t.size() != u.size() || t.size() != v.size() || t.size() != w.size()) {
          throw new IllegalArgumentException();
       }
-      List<Quartet<T, U, V, W>> list = new ArrayList<Quartet<T, U, V, W>>(t.size());
+      List<Quadruple<T, U, V, W>> list = new ArrayList<Quadruple<T, U, V, W>>(t.size());
       Iterator<T> tIter = t.iterator();
       Iterator<U> uIter = u.iterator();
       Iterator<V> vIter = v.iterator();
       Iterator<W> wIter = w.iterator();
       while (tIter.hasNext() && uIter.hasNext() && vIter.hasNext() && wIter.hasNext()) {
-         list.add(create(tIter.next(), uIter.next(), vIter.next(), wIter.next()));
+         list.add(of(tIter.next(), uIter.next(), vIter.next(), wIter.next()));
       }
       if (tIter.hasNext() || uIter.hasNext() || vIter.hasNext() || wIter.hasNext()) {
          // size changed since check above such that collections differ
@@ -119,7 +119,7 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
    private final C c;
    private final D d;
    
-   private Quartet(A a, B b, C c, D d) {
+   private Quadruple(A a, B b, C c, D d) {
       this.a = a;
       this.b = b;
       this.c = c;
@@ -135,8 +135,8 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
     * @param d the fourth item in the quartet
     * @return a new quartet
     */
-   public static <A, B, C, D> Quartet<A, B, C, D> create(A a, B b, C c, D d) {
-      return new Quartet<A, B, C, D>(a, b, c, d);
+   public static <A, B, C, D> Quadruple<A, B, C, D> of(A a, B b, C c, D d) {
+      return new Quadruple<A, B, C, D>(a, b, c, d);
    }
 
    @Override
@@ -183,99 +183,99 @@ public final class Quartet<A, B, C, D> implements Tuple.Ops4<A, B, C, D>, Serial
    }
 
    @Override
-   public <T> Quartet<T, B, C, D> setFirst(T t) {
-      return Quartet.create(t, b, c, d);
+   public <T> Quadruple<T, B, C, D> setFirst(T t) {
+      return Quadruple.of(t, b, c, d);
    }
 
    @Override
-   public <T> Quartet<A, T, C, D> setSecond(T t) {
-      return Quartet.create(a, t, c, d);
+   public <T> Quadruple<A, T, C, D> setSecond(T t) {
+      return Quadruple.of(a, t, c, d);
    }
 
    @Override
-   public <T> Quartet<A, B, T, D> setThird(T t) {
-      return Quartet.create(a, b, t, d);
+   public <T> Quadruple<A, B, T, D> setThird(T t) {
+      return Quadruple.of(a, b, t, d);
    }
 
    @Override
-   public <T> Quartet<A, B, C, T> setFourth(T t) {
-      return Quartet.create(a, b, c, t);
+   public <T> Quadruple<A, B, C, T> setFourth(T t) {
+      return Quadruple.of(a, b, c, t);
    }
 
    @Override
-   public Trio<B, C, D> removeFirst() {
-      return Trio.create(b, c, d);
+   public Triple<B, C, D> removeFirst() {
+      return Triple.of(b, c, d);
    }
 
    @Override
-   public Trio<A, C, D> removeSecond() {
-      return Trio.create(a, c, d);
+   public Triple<A, C, D> removeSecond() {
+      return Triple.of(a, c, d);
    }
 
    @Override
-   public Trio<A, B, D> removeThird() {
-      return Trio.create(a, b, d);
+   public Triple<A, B, D> removeThird() {
+      return Triple.of(a, b, d);
    }
 
    @Override
-   public Trio<A, B, C> removeFourth() {
-      return Trio.create(a, b, c);
+   public Triple<A, B, C> removeFourth() {
+      return Triple.of(a, b, c);
    }
 
    @Override
-   public <T> Quintet<A, B, C, D, T> add(T t) {
-      return Quintet.create(a, b, c, d, t);
+   public <T> Quintuple<A, B, C, D, T> add(T t) {
+      return Quintuple.of(a, b, c, d, t);
    }
 
    @Override
-   public <T> Quintet<T, A, B, C, D> insertFirst(T t) {
-      return Quintet.create(t, a, b, c, d);
+   public <T> Quintuple<T, A, B, C, D> insertFirst(T t) {
+      return Quintuple.of(t, a, b, c, d);
    }
 
    @Override
-   public <T> Quintet<A, T, B, C, D> insertSecond(T t) {
-      return Quintet.create(a, t, b, c, d);
+   public <T> Quintuple<A, T, B, C, D> insertSecond(T t) {
+      return Quintuple.of(a, t, b, c, d);
    }
 
    @Override
-   public <T> Quintet<A, B, T, C, D> insertThird(T t) {
-      return Quintet.create(a, b, t, c, d);
+   public <T> Quintuple<A, B, T, C, D> insertThird(T t) {
+      return Quintuple.of(a, b, t, c, d);
    }
 
    @Override
-   public <T> Quintet<A, B, C, T, D> insertFourth(T t) {
-      return Quintet.create(a, b, c, t, d);
+   public <T> Quintuple<A, B, C, T, D> insertFourth(T t) {
+      return Quintuple.of(a, b, c, t, d);
    }
 
    @Override
-   public <T> Quintet<A, B, C, D, T> insertFifth(T t) {
+   public <T> Quintuple<A, B, C, D, T> insertFifth(T t) {
       return add(t);
    }
 
    @Override
-   public <T> Quartet<T, T, T, T> transformAll(Function<Object, ? extends T> function) {
-      return Quartet.<T, T, T, T>create(function.apply(a), function.apply(b), function.apply(c),
+   public <T> Quadruple<T, T, T, T> transformAll(Function<Object, ? extends T> function) {
+      return Quadruple.<T, T, T, T>of(function.apply(a), function.apply(b), function.apply(c),
             function.apply(d));
    }
 
    @Override
-   public <T> Quartet<T, B, C, D> transformFirst(Function<? super A, ? extends T> function) {
-      return Quartet.<T, B, C, D>create(function.apply(a), b, c, d);
+   public <T> Quadruple<T, B, C, D> transformFirst(Function<? super A, ? extends T> function) {
+      return Quadruple.<T, B, C, D>of(function.apply(a), b, c, d);
    }
 
    @Override
-   public <T> Quartet<A, T, C, D> transformSecond(Function<? super B, ? extends T> function) {
-      return Quartet.<A, T, C, D>create(a, function.apply(b), c, d);
+   public <T> Quadruple<A, T, C, D> transformSecond(Function<? super B, ? extends T> function) {
+      return Quadruple.<A, T, C, D>of(a, function.apply(b), c, d);
    }
 
    @Override
-   public <T> Quartet<A, B, T, D> transformThird(Function<? super C, ? extends T> function) {
-      return Quartet.<A, B, T, D>create(a, b, function.apply(c), d);
+   public <T> Quadruple<A, B, T, D> transformThird(Function<? super C, ? extends T> function) {
+      return Quadruple.<A, B, T, D>of(a, b, function.apply(c), d);
    }
 
    @Override
-   public <T> Quartet<A, B, C, T> transformFourth(Function<? super D, ? extends T> function) {
-      return Quartet.<A, B, C, T>create(a, b, c, function.apply(d));
+   public <T> Quadruple<A, B, C, T> transformFourth(Function<? super D, ? extends T> function) {
+      return Quadruple.<A, B, C, T>of(a, b, c, function.apply(d));
    }
    
    @Override

--- a/src/com/bluegosling/tuples/Quintuple.java
+++ b/src/com/bluegosling/tuples/Quintuple.java
@@ -22,7 +22,7 @@ import com.bluegosling.util.ValueType;
  * @param <E> the type of the fifth item
  */
 @ValueType
-public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, Serializable {
+public final class Quintuple<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, Serializable {
 
    private static final long serialVersionUID = -6961697944717178646L;
 
@@ -36,7 +36,7 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
     * @return a list view of the specified quintet
     */
    @SuppressWarnings("unchecked") // thanks to type bounds, we know the cast is safe
-   public static <T> List<T> asTypedList(Quintet<? extends T, ? extends T, ? extends T, ? extends T, ? extends T> quintet) {
+   public static <T> List<T> asTypedList(Quintuple<? extends T, ? extends T, ? extends T, ? extends T, ? extends T> quintet) {
       return (List<T>) quintet.asList();
    }
    
@@ -49,21 +49,21 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
     * @param quintets a collection of quintet
     * @return a quintet of lists whose values were extracted from the collection of quintets
     */
-   public static <T, U, V, W, X> Quintet<List<T>, List<U>, List<V>, List<W>, List<X>> separate(
-         Collection<Quintet<T, U, V, W, X>> quintets) {
+   public static <T, U, V, W, X> Quintuple<List<T>, List<U>, List<V>, List<W>, List<X>> separate(
+         Collection<Quintuple<T, U, V, W, X>> quintets) {
       List<T> t = new ArrayList<T>(quintets.size());
       List<U> u = new ArrayList<U>(quintets.size());
       List<V> v = new ArrayList<V>(quintets.size());
       List<W> w = new ArrayList<W>(quintets.size());
       List<X> x = new ArrayList<X>(quintets.size());
-      for (Quintet<T, U, V, W, X> quintet : quintets) {
+      for (Quintuple<T, U, V, W, X> quintet : quintets) {
          t.add(quintet.getFirst());
          u.add(quintet.getSecond());
          v.add(quintet.getThird());
          w.add(quintet.getFourth());
          x.add(quintet.getFifth());
       }
-      return create(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
+      return of(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
             Collections.unmodifiableList(v), Collections.unmodifiableList(w),
             Collections.unmodifiableList(x));
    }
@@ -78,8 +78,8 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
     * @return a list of quintets, each one representing corresponding values from the collections
     * @throws IllegalArgumentException if any collection has a different size than the others
     */   
-   public static <T, U, V, W, X> List<Quintet<T, U, V, W, X>> combine(
-         Quintet<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>,
+   public static <T, U, V, W, X> List<Quintuple<T, U, V, W, X>> combine(
+         Quintuple<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>,
                ? extends Collection<W>, ? extends Collection<X>> quintet) {
       return combine(quintet.getFirst(), quintet.getSecond(), quintet.getThird(),
             quintet.getFourth(), quintet.getFifth());
@@ -99,13 +99,13 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
     * @return a list of quintets, each one representing corresponding values from the collections
     * @throws IllegalArgumentException if any collection has a different size than the others
     */
-   public static <T, U, V, W, X> List<Quintet<T, U, V, W, X>> combine(Collection<T> t,
+   public static <T, U, V, W, X> List<Quintuple<T, U, V, W, X>> combine(Collection<T> t,
          Collection<U> u, Collection<V> v, Collection<W> w, Collection<X> x) {
       if (t.size() != u.size() || t.size() != v.size() || t.size() != w.size()
             || t.size() != x.size()) {
          throw new IllegalArgumentException();
       }
-      List<Quintet<T, U, V, W, X>> list = new ArrayList<Quintet<T, U, V, W, X>>(t.size());
+      List<Quintuple<T, U, V, W, X>> list = new ArrayList<Quintuple<T, U, V, W, X>>(t.size());
       Iterator<T> tIter = t.iterator();
       Iterator<U> uIter = u.iterator();
       Iterator<V> vIter = v.iterator();
@@ -113,7 +113,7 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
       Iterator<X> xIter = x.iterator();
       while (tIter.hasNext() && uIter.hasNext() && vIter.hasNext() && wIter.hasNext()
             && xIter.hasNext()) {
-         list.add(create(tIter.next(), uIter.next(), vIter.next(), wIter.next(), xIter.next()));
+         list.add(of(tIter.next(), uIter.next(), vIter.next(), wIter.next(), xIter.next()));
       }
       if (tIter.hasNext() || uIter.hasNext() || vIter.hasNext() || wIter.hasNext()
             || xIter.hasNext()) {
@@ -129,7 +129,7 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
    private final D d;
    private final E e;
    
-   private Quintet(A a, B b, C c, D d, E e) {
+   private Quintuple(A a, B b, C c, D d, E e) {
       this.a = a;
       this.b = b;
       this.c = c;
@@ -147,8 +147,8 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
     * @param e the fifth item in the quintet
     * @return a new quintet
     */
-   public static <A, B, C, D, E> Quintet<A, B, C, D, E> create(A a, B b, C c, D d, E e) {
-      return new Quintet<A, B, C, D, E>(a, b, c, d, e);
+   public static <A, B, C, D, E> Quintuple<A, B, C, D, E> of(A a, B b, C c, D d, E e) {
+      return new Quintuple<A, B, C, D, E>(a, b, c, d, e);
    }
 
    @Override
@@ -201,53 +201,53 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
    }
 
    @Override
-   public <T> Quintet<T, B, C, D, E> setFirst(T t) {
-      return Quintet.create(t, b, c, d, e);
+   public <T> Quintuple<T, B, C, D, E> setFirst(T t) {
+      return Quintuple.of(t, b, c, d, e);
    }
 
    @Override
-   public <T> Quintet<A, T, C, D, E> setSecond(T t) {
-      return Quintet.create(a, t, c, d, e);
+   public <T> Quintuple<A, T, C, D, E> setSecond(T t) {
+      return Quintuple.of(a, t, c, d, e);
    }
 
    @Override
-   public <T> Quintet<A, B, T, D, E> setThird(T t) {
-      return Quintet.create(a, b, t, d, e);
+   public <T> Quintuple<A, B, T, D, E> setThird(T t) {
+      return Quintuple.of(a, b, t, d, e);
    }
 
    @Override
-   public <T> Quintet<A, B, C, T, E> setFourth(T t) {
-      return Quintet.create(a, b, c, t, e);
+   public <T> Quintuple<A, B, C, T, E> setFourth(T t) {
+      return Quintuple.of(a, b, c, t, e);
    }
 
    @Override
-   public <T> Quintet<A, B, C, D, T> setFifth(T t) {
-      return Quintet.create(a, b, c, d, t);
+   public <T> Quintuple<A, B, C, D, T> setFifth(T t) {
+      return Quintuple.of(a, b, c, d, t);
    }
 
    @Override
-   public Quartet<B, C, D, E> removeFirst() {
-      return Quartet.create(b, c, d, e);
+   public Quadruple<B, C, D, E> removeFirst() {
+      return Quadruple.of(b, c, d, e);
    }
 
    @Override
-   public Quartet<A, C, D, E> removeSecond() {
-      return Quartet.create(a, c, d, e);
+   public Quadruple<A, C, D, E> removeSecond() {
+      return Quadruple.of(a, c, d, e);
    }
 
    @Override
-   public Quartet<A, B, D, E> removeThird() {
-      return Quartet.create(a, b, d, e);
+   public Quadruple<A, B, D, E> removeThird() {
+      return Quadruple.of(a, b, d, e);
    }
 
    @Override
-   public Quartet<A, B, C, E> removeFourth() {
-      return Quartet.create(a, b, c, e);
+   public Quadruple<A, B, C, E> removeFourth() {
+      return Quadruple.of(a, b, c, e);
    }
 
    @Override
-   public Quartet<A, B, C, D> removeFifth() {
-      return Quartet.create(a, b, c, d);
+   public Quadruple<A, B, C, D> removeFifth() {
+      return Quadruple.of(a, b, c, d);
    }
 
    @Override
@@ -281,34 +281,34 @@ public final class Quintet<A, B, C, D, E> implements Tuple.Ops5<A, B, C, D, E>, 
    }
 
    @Override
-   public <T> Quintet<T, T, T, T, T> transformAll(Function<Object, ? extends T> function) {
-      return Quintet.<T, T, T, T, T>create(function.apply(a), function.apply(b), function.apply(c),
+   public <T> Quintuple<T, T, T, T, T> transformAll(Function<Object, ? extends T> function) {
+      return Quintuple.<T, T, T, T, T>of(function.apply(a), function.apply(b), function.apply(c),
             function.apply(d), function.apply(e));
    }
 
    @Override
-   public <T> Quintet<T, B, C, D, E> transformFirst(Function<? super A, ? extends T> function) {
-      return Quintet.<T, B, C, D, E>create(function.apply(a), b, c, d, e);
+   public <T> Quintuple<T, B, C, D, E> transformFirst(Function<? super A, ? extends T> function) {
+      return Quintuple.<T, B, C, D, E>of(function.apply(a), b, c, d, e);
    }
 
    @Override
-   public <T> Quintet<A, T, C, D, E> transformSecond(Function<? super B, ? extends T> function) {
-      return Quintet.<A, T, C, D, E>create(a, function.apply(b), c, d, e);
+   public <T> Quintuple<A, T, C, D, E> transformSecond(Function<? super B, ? extends T> function) {
+      return Quintuple.<A, T, C, D, E>of(a, function.apply(b), c, d, e);
    }
 
    @Override
-   public <T> Quintet<A, B, T, D, E> transformThird(Function<? super C, ? extends T> function) {
-      return Quintet.<A, B, T, D, E>create(a, b, function.apply(c), d, e);
+   public <T> Quintuple<A, B, T, D, E> transformThird(Function<? super C, ? extends T> function) {
+      return Quintuple.<A, B, T, D, E>of(a, b, function.apply(c), d, e);
    }
 
    @Override
-   public <T> Quintet<A, B, C, T, E> transformFourth(Function<? super D, ? extends T> function) {
-      return Quintet.<A, B, C, T, E>create(a, b, c, function.apply(d), e);
+   public <T> Quintuple<A, B, C, T, E> transformFourth(Function<? super D, ? extends T> function) {
+      return Quintuple.<A, B, C, T, E>of(a, b, c, function.apply(d), e);
    }
 
    @Override
-   public <T> Quintet<A, B, C, D, T> transformFifth(Function<? super E, ? extends T> function) {
-      return Quintet.<A, B, C, D, T>create(a, b, c, d, function.apply(e));
+   public <T> Quintuple<A, B, C, D, T> transformFifth(Function<? super E, ? extends T> function) {
+      return Quintuple.<A, B, C, D, T>of(a, b, c, d, function.apply(e));
    }
    
    @Override

--- a/src/com/bluegosling/tuples/Single.java
+++ b/src/com/bluegosling/tuples/Single.java
@@ -19,7 +19,7 @@ import com.bluegosling.util.ValueType;
  * @param <A> the element type
  */
 @ValueType
-public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
+public final class Single<A> implements Tuple.Ops1<A>, Serializable {
 
    private static final long serialVersionUID = -9201943154135089064L;
    
@@ -32,9 +32,9 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
     * @param units a collection of units
     * @return the list of values, extracted from the units
     */
-   public static <T> List<T> extract(Collection<Unit<T>> units) {
+   public static <T> List<T> extract(Collection<Single<T>> units) {
       List<T> extracted = new ArrayList<T>(units.size());
-      for (Unit<T> unit : units) {
+      for (Single<T> unit : units) {
          extracted.add(unit.getFirst());
       }
       return Collections.unmodifiableList(extracted);
@@ -49,17 +49,17 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
     * @param coll a collection of values
     * @return a list of units, each one representing a corresponding value in the collection
     */
-   public static <T> List<Unit<T>> enclose(Collection<? extends T> coll) {
-      List<Unit<T>> enclosed = new ArrayList<Unit<T>>(coll.size());
+   public static <T> List<Single<T>> enclose(Collection<? extends T> coll) {
+      List<Single<T>> enclosed = new ArrayList<Single<T>>(coll.size());
       for (T t : coll) {
-         enclosed.add(create(t));
+         enclosed.add(of(t));
       }
       return Collections.unmodifiableList(enclosed);
    }
 
    private final A a;
    
-   private Unit(A a) {
+   private Single(A a) {
       this.a = a;
    }
    
@@ -69,8 +69,8 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
     * @param t the sole element
     * @return a new tuple with the one specified item
     */
-   public static <T> Unit<T> create(T t) {
-      return new Unit<T>(t);
+   public static <T> Single<T> of(T t) {
+      return new Single<T>(t);
    }
    
    /**
@@ -111,8 +111,8 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
    }
 
    @Override
-   public <T> Unit<T> setFirst(T t) {
-      return new Unit<T>(t);
+   public <T> Single<T> setFirst(T t) {
+      return new Single<T>(t);
    }
 
    @Override
@@ -122,12 +122,12 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
 
    @Override
    public <T> Pair<A, T> add(T t) {
-      return Pair.create(a, t);
+      return Pair.of(a, t);
    }
 
    @Override
    public <T> Pair<T, A> insertFirst(T t) {
-      return Pair.create(t, a);
+      return Pair.of(t, a);
    }
 
    @Override
@@ -136,13 +136,13 @@ public final class Unit<A> implements Tuple.Ops1<A>, Serializable {
    }
 
    @Override
-   public <T> Unit<T> transformAll(Function<Object, ? extends T> function) {
+   public <T> Single<T> transformAll(Function<Object, ? extends T> function) {
       return transformFirst(function);
    }
 
    @Override
-   public <T> Unit<T> transformFirst(Function<? super A, ? extends T> function) {
-      return Unit.<T>create(function.apply(a));
+   public <T> Single<T> transformFirst(Function<? super A, ? extends T> function) {
+      return Single.<T>of(function.apply(a));
       
    }
    

--- a/src/com/bluegosling/tuples/Triple.java
+++ b/src/com/bluegosling/tuples/Triple.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * @param <C> the type of the third item
  */
 @ValueType
-public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
+public final class Triple<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
 
    private static final long serialVersionUID = -2245545958928314038L;
 
@@ -36,7 +36,7 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
     * @return a list view of the specified trio
     */
    @SuppressWarnings("unchecked") // thanks to type bounds, we know the cast is safe
-   public static <T> List<T> asTypedList(Trio<? extends T, ? extends T, ? extends T> trio) {
+   public static <T> List<T> asTypedList(Triple<? extends T, ? extends T, ? extends T> trio) {
       return (List<T>) trio.asList();
    }
    
@@ -49,17 +49,17 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
     * @param trios a collection of trios
     * @return a trio of lists whose values were extracted from the collection of trios
     */
-   public static <T, U, V> Trio<List<T>, List<U>, List<V>> separate(
-         Collection<Trio<T, U, V>> trios) {
+   public static <T, U, V> Triple<List<T>, List<U>, List<V>> separate(
+         Collection<Triple<T, U, V>> trios) {
       List<T> t = new ArrayList<T>(trios.size());
       List<U> u = new ArrayList<U>(trios.size());
       List<V> v = new ArrayList<V>(trios.size());
-      for (Trio<T, U, V> trio : trios) {
+      for (Triple<T, U, V> trio : trios) {
          t.add(trio.getFirst());
          u.add(trio.getSecond());
          v.add(trio.getThird());
       }
-      return create(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
+      return of(Collections.unmodifiableList(t), Collections.unmodifiableList(u),
             Collections.unmodifiableList(v));
    }
 
@@ -73,8 +73,8 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
     * @return a list of trios, each one representing corresponding values from the collection
     * @throws IllegalArgumentException if any collection has a different size than the others
     */   
-   public static <T, U, V> List<Trio<T, U, V>> combine(
-         Trio<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>> trio) {
+   public static <T, U, V> List<Triple<T, U, V>> combine(
+         Triple<? extends Collection<T>, ? extends Collection<U>, ? extends Collection<V>> trio) {
       return combine(trio.getFirst(), trio.getSecond(), trio.getThird());
    }
    
@@ -90,17 +90,17 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
     * @return a list of trios, each one representing corresponding values from the collections
     * @throws IllegalArgumentException if any collection has a different size than the others
     */
-   public static <T, U, V> List<Trio<T, U, V>> combine(Collection<T> t, Collection<U> u,
+   public static <T, U, V> List<Triple<T, U, V>> combine(Collection<T> t, Collection<U> u,
          Collection<V> v) {
       if (t.size() != u.size() || t.size() != v.size()) {
          throw new IllegalArgumentException();
       }
-      List<Trio<T, U, V>> list = new ArrayList<Trio<T, U, V>>(t.size());
+      List<Triple<T, U, V>> list = new ArrayList<Triple<T, U, V>>(t.size());
       Iterator<T> tIter = t.iterator();
       Iterator<U> uIter = u.iterator();
       Iterator<V> vIter = v.iterator();
       while (tIter.hasNext() && uIter.hasNext() && vIter.hasNext()) {
-         list.add(create(tIter.next(), uIter.next(), vIter.next()));
+         list.add(of(tIter.next(), uIter.next(), vIter.next()));
       }
       if (tIter.hasNext() || uIter.hasNext() || vIter.hasNext()) {
          // size changed since check above such that collections differ
@@ -113,7 +113,7 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
    private final B b;
    private final C c;
    
-   private Trio(A a, B b, C c) {
+   private Triple(A a, B b, C c) {
       this.a = a;
       this.b = b;
       this.c = c;
@@ -127,8 +127,8 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
     * @param c the third item in the trio
     * @return a new trio
     */
-   public static <A, B, C> Trio<A, B, C> create(A a, B b, C c) {
-      return new Trio<A, B, C>(a, b, c);
+   public static <A, B, C> Triple<A, B, C> of(A a, B b, C c) {
+      return new Triple<A, B, C>(a, b, c);
    }
 
    @Override
@@ -169,78 +169,78 @@ public final class Trio<A, B, C> implements Tuple.Ops3<A, B, C>, Serializable {
    }
 
    @Override
-   public <T> Trio<T, B, C> setFirst(T t) {
-      return Trio.create(t, b, c);
+   public <T> Triple<T, B, C> setFirst(T t) {
+      return Triple.of(t, b, c);
    }
 
    @Override
-   public <T> Trio<A, T, C> setSecond(T t) {
-      return Trio.create(a, t, c);
+   public <T> Triple<A, T, C> setSecond(T t) {
+      return Triple.of(a, t, c);
    }
 
    @Override
-   public <T> Trio<A, B, T> setThird(T t) {
-      return Trio.create(a, b, t);
+   public <T> Triple<A, B, T> setThird(T t) {
+      return Triple.of(a, b, t);
    }
 
    @Override
    public Pair<B, C> removeFirst() {
-      return Pair.create(b, c);
+      return Pair.of(b, c);
    }
 
    @Override
    public Pair<A, C> removeSecond() {
-      return Pair.create(a, c);
+      return Pair.of(a, c);
    }
 
    @Override
    public Pair<A, B> removeThird() {
-      return Pair.create(a, b);
+      return Pair.of(a, b);
    }
 
    @Override
-   public <T> Quartet<A, B, C, T> add(T t) {
-      return Quartet.create(a, b, c, t);
+   public <T> Quadruple<A, B, C, T> add(T t) {
+      return Quadruple.of(a, b, c, t);
    }
 
    @Override
-   public <T> Quartet<T, A, B, C> insertFirst(T t) {
-      return Quartet.create(t, a, b, c);
+   public <T> Quadruple<T, A, B, C> insertFirst(T t) {
+      return Quadruple.of(t, a, b, c);
    }
 
    @Override
-   public <T> Quartet<A, T, B, C> insertSecond(T t) {
-      return Quartet.create(a, t, b, c);
+   public <T> Quadruple<A, T, B, C> insertSecond(T t) {
+      return Quadruple.of(a, t, b, c);
    }
 
    @Override
-   public <T> Quartet<A, B, T, C> insertThird(T t) {
-      return Quartet.create(a, b, t, c);
+   public <T> Quadruple<A, B, T, C> insertThird(T t) {
+      return Quadruple.of(a, b, t, c);
    }
 
    @Override
-   public <T> Quartet<A, B, C, T> insertFourth(T t) {
+   public <T> Quadruple<A, B, C, T> insertFourth(T t) {
       return add(t);
    }
 
    @Override
-   public <T> Trio<T, T, T> transformAll(Function<Object, ? extends T> function) {
-      return Trio.<T, T, T>create(function.apply(a), function.apply(b), function.apply(c));
+   public <T> Triple<T, T, T> transformAll(Function<Object, ? extends T> function) {
+      return Triple.<T, T, T>of(function.apply(a), function.apply(b), function.apply(c));
    }
 
    @Override
-   public <T> Trio<T, B, C> transformFirst(Function<? super A, ? extends T> function) {
-      return Trio.<T, B, C>create(function.apply(a), b, c);
+   public <T> Triple<T, B, C> transformFirst(Function<? super A, ? extends T> function) {
+      return Triple.<T, B, C>of(function.apply(a), b, c);
    }
 
    @Override
-   public <T> Trio<A, T, C> transformSecond(Function<? super B, ? extends T> function) {
-      return Trio.<A, T, C>create(a, function.apply(b), c);
+   public <T> Triple<A, T, C> transformSecond(Function<? super B, ? extends T> function) {
+      return Triple.<A, T, C>of(a, function.apply(b), c);
    }
 
    @Override
-   public <T> Trio<A, B, T> transformThird(Function<? super C, ? extends T> function) {
-      return Trio.<A, B, T>create(a, b, function.apply(c));
+   public <T> Triple<A, B, T> transformThird(Function<? super C, ? extends T> function) {
+      return Triple.<A, B, T>of(a, b, function.apply(c));
    }
    
    /**

--- a/src/com/bluegosling/tuples/Tuples.java
+++ b/src/com/bluegosling/tuples/Tuples.java
@@ -31,8 +31,8 @@ public final class Tuples {
     * will be the first item in the array, and so on.
     * 
     * If the specified array is empty, {@link Empty#INSTANCE} will be returned. If the array has
-    * exactly one, two, three, four, or five elements then a {@link Unit}, {@link Pair},
-    * {@link Trio}, {@link Quartet}, or {@link Quintet} will be returned, respectively. If the
+    * exactly one, two, three, four, or five elements then a {@link Single}, {@link Pair},
+    * {@link Triple}, {@link Quadruple}, or {@link Quintuple} will be returned, respectively. If the
     * array has more than five elements than an {@link NTuple} is returned.
     * 
     * @param array the array
@@ -43,15 +43,15 @@ public final class Tuples {
          case 0:
             return Empty.INSTANCE;
          case 1:
-            return Unit.create(array[0]);
+            return Single.of(array[0]);
          case 2:
-            return Pair.create(array[0], array[1]);
+            return Pair.of(array[0], array[1]);
          case 3:
-            return Trio.create(array[0], array[1], array[2]);
+            return Triple.of(array[0], array[1], array[2]);
          case 4:
-            return Quartet.create(array[0], array[1], array[2], array[3]);
+            return Quadruple.of(array[0], array[1], array[2], array[3]);
          case 5:
-            return Quintet.create(array[0], array[1], array[2], array[3], array[4]);
+            return Quintuple.of(array[0], array[1], array[2], array[3], array[4]);
          default:
             return NTuple.create(array[0], array[1], array[2], array[3], array[4], array[5],
                   getRemaining(array, 6));
@@ -101,9 +101,9 @@ public final class Tuples {
    }
 
    public <A extends Comparable<A>, B extends Comparable<B>, C extends Comparable<C>>
-   Comparator<Trio<A, B, C>> trioNaturalOrdering() {
-      return new Comparator<Trio<A, B, C>>() {
-         @Override public int compare(Trio<A, B, C> o1, Trio<A, B, C> o2) {
+   Comparator<Triple<A, B, C>> trioNaturalOrdering() {
+      return new Comparator<Triple<A, B, C>>() {
+         @Override public int compare(Triple<A, B, C> o1, Triple<A, B, C> o2) {
             int c = o1.getFirst().compareTo(o2.getFirst());
             if (c == 0) {
                c = o1.getSecond().compareTo(o2.getSecond());
@@ -115,9 +115,9 @@ public final class Tuples {
 
    public <A extends Comparable<A>, B extends Comparable<B>, C extends Comparable<C>,
             D extends Comparable<D>>
-   Comparator<Quartet<A, B, C, D>> quartetNaturalOrdering() {
-      return new Comparator<Quartet<A, B, C, D>>() {
-         @Override public int compare(Quartet<A, B, C, D> o1, Quartet<A, B, C, D> o2) {
+   Comparator<Quadruple<A, B, C, D>> quartetNaturalOrdering() {
+      return new Comparator<Quadruple<A, B, C, D>>() {
+         @Override public int compare(Quadruple<A, B, C, D> o1, Quadruple<A, B, C, D> o2) {
             int c = o1.getFirst().compareTo(o2.getFirst());
             if (c == 0) {
                c = o1.getSecond().compareTo(o2.getSecond());
@@ -132,9 +132,9 @@ public final class Tuples {
    
    public <A extends Comparable<A>, B extends Comparable<B>, C extends Comparable<C>,
             D extends Comparable<D>, E extends Comparable<E>>
-   Comparator<Quintet<A, B, C, D, E>> quintetNaturalOrdering() {
-      return new Comparator<Quintet<A, B, C, D, E>>() {
-         @Override public int compare(Quintet<A, B, C, D, E> o1, Quintet<A, B, C, D, E> o2) {
+   Comparator<Quintuple<A, B, C, D, E>> quintetNaturalOrdering() {
+      return new Comparator<Quintuple<A, B, C, D, E>>() {
+         @Override public int compare(Quintuple<A, B, C, D, E> o1, Quintuple<A, B, C, D, E> o2) {
             int c = o1.getFirst().compareTo(o2.getFirst());
             if (c == 0) {
                c = o1.getSecond().compareTo(o2.getSecond());

--- a/test/com/bluegosling/concurrent/atoms/AbstractSynchronousAtomTest.java
+++ b/test/com/bluegosling/concurrent/atoms/AbstractSynchronousAtomTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 import org.junit.Test;
 
@@ -84,14 +84,14 @@ public abstract class AbstractSynchronousAtomTest {
    }
    
    @Test public void watchers() {
-      List<Trio<Atom<? extends String>, String, String>> notices1 =
-            new ArrayList<Trio<Atom<? extends String>, String, String>>();
-      List<Trio<Atom<? extends String>, String, String>> notices2 =
-            new ArrayList<Trio<Atom<? extends String>, String, String>>();
+      List<Triple<Atom<? extends String>, String, String>> notices1 =
+            new ArrayList<Triple<Atom<? extends String>, String, String>>();
+      List<Triple<Atom<? extends String>, String, String>> notices2 =
+            new ArrayList<Triple<Atom<? extends String>, String, String>>();
       Atom.Watcher<String> watcher1 = (atom, oldValue, newValue) ->
-            notices1.add(Trio.create(atom, oldValue, newValue));
+            notices1.add(Triple.of(atom, oldValue, newValue));
       Atom.Watcher<String> watcher2 = (atom, oldValue, newValue) ->
-            notices2.add(Trio.create(atom, oldValue, newValue));
+            notices2.add(Triple.of(atom, oldValue, newValue));
 
       SynchronousAtom<String> atom = create();
       atom.addWatcher(watcher1);
@@ -111,20 +111,20 @@ public abstract class AbstractSynchronousAtomTest {
    protected void checkWatchers(SynchronousAtom<String> atom, List<?>... noticesArray) {
       atom.set("abc");
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, null, "abc")), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, null, "abc")), notices);
          notices.clear();
       }
       
       Function<String,String> twice = i -> i + i;
       atom.updateAndGet(twice);
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, "abc", "abcabc")), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, "abc", "abcabc")), notices);
          notices.clear();
       }
       
       atom.set(null); // reset
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, "abcabc", null)), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, "abcabc", null)), notices);
          notices.clear();
       }
    }

--- a/test/com/bluegosling/concurrent/atoms/AsynchronousAtomTest.java
+++ b/test/com/bluegosling/concurrent/atoms/AsynchronousAtomTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 import org.junit.Test;
 
@@ -80,14 +80,14 @@ public class AsynchronousAtomTest {
    }
    
    @Test public void watchers() throws Exception {
-      List<Trio<Atom<? extends String>, String, String>> notices1 =
-            new ArrayList<Trio<Atom<? extends String>, String, String>>();
-      List<Trio<Atom<? extends String>, String, String>> notices2 =
-            new ArrayList<Trio<Atom<? extends String>, String, String>>();
+      List<Triple<Atom<? extends String>, String, String>> notices1 =
+            new ArrayList<Triple<Atom<? extends String>, String, String>>();
+      List<Triple<Atom<? extends String>, String, String>> notices2 =
+            new ArrayList<Triple<Atom<? extends String>, String, String>>();
       Atom.Watcher<String> watcher1 = (atom, oldValue, newValue) ->
-            notices1.add(Trio.create(atom, oldValue, newValue));
+            notices1.add(Triple.of(atom, oldValue, newValue));
       Atom.Watcher<String> watcher2 = (atom, oldValue, newValue) ->
-            notices2.add(Trio.create(atom, oldValue, newValue));
+            notices2.add(Triple.of(atom, oldValue, newValue));
 
       AsynchronousAtom<String> atom = new AsynchronousAtom<>();
       atom.addWatcher(watcher1);
@@ -108,20 +108,20 @@ public class AsynchronousAtomTest {
          throws Exception {
       atom.set("abc").get();
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, null, "abc")), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, null, "abc")), notices);
          notices.clear();
       }
       
       Function<String,String> twice = i -> i + i;
       atom.updateAndGet(twice).get();
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, "abc", "abcabc")), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, "abc", "abcabc")), notices);
          notices.clear();
       }
       
       atom.set(null).get(); // reset
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(atom, "abcabc", null)), notices);
+         assertEquals(Arrays.asList(Triple.of(atom, "abcabc", null)), notices);
          notices.clear();
       }
    }

--- a/test/com/bluegosling/concurrent/atoms/ThreadLocalAtomTest.java
+++ b/test/com/bluegosling/concurrent/atoms/ThreadLocalAtomTest.java
@@ -3,7 +3,7 @@ package com.bluegosling.concurrent.atoms;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 import org.junit.Test;
 
@@ -52,12 +52,12 @@ public class ThreadLocalAtomTest extends AbstractSynchronousAtomTest {
       ThreadLocalAtom<String> tla = (ThreadLocalAtom<String>) atom;
       tla.setRootValue("abc");
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(tla, null, "abc")), notices);
+         assertEquals(Arrays.asList(Triple.of(tla, null, "abc")), notices);
          notices.clear();
       }
       tla.setRootValue(null);
       for (List<?> notices : noticesArray) {
-         assertEquals(Arrays.asList(Trio.create(tla, "abc", null)), notices);
+         assertEquals(Arrays.asList(Triple.of(tla, "abc", null)), notices);
          notices.clear();
       }
    }

--- a/test/com/bluegosling/concurrent/atoms/TransactionalAtomTest.java
+++ b/test/com/bluegosling/concurrent/atoms/TransactionalAtomTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.bluegosling.concurrent.fluent.FluentFuture;
 import com.bluegosling.possible.Holder;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 
 import org.junit.Test;
 
@@ -54,14 +54,14 @@ public class TransactionalAtomTest extends AbstractSynchronousAtomTest {
       assertEquals("ABC", atom.get());
       
       // w/ watcher
-      List<Trio<Atom<? extends String>, String, String>> notices =
-            new ArrayList<Trio<Atom<? extends String>, String, String>>();
+      List<Triple<Atom<? extends String>, String, String>> notices =
+            new ArrayList<Triple<Atom<? extends String>, String, String>>();
       Atom.Watcher<String> watcher = (a, oldValue, newValue) ->
-            notices.add(Trio.create(a, oldValue, newValue));
+            notices.add(Triple.of(a, oldValue, newValue));
       atom.addWatcher(watcher);
       Function<String, String> twice = (s) -> s + s;
       result = atom.commute(twice);
-      assertEquals(Arrays.asList(Trio.create(atom, "ABC", "ABCABC")), notices);
+      assertEquals(Arrays.asList(Triple.of(atom, "ABC", "ABCABC")), notices);
       notices.clear();
       assertTrue(result.isDone());
       assertEquals("ABCABC", result.get());
@@ -139,10 +139,10 @@ public class TransactionalAtomTest extends AbstractSynchronousAtomTest {
 
    @Test public void watchers_inTransaction() {
       TransactionalAtom<String> atom = create("");
-      List<Trio<Atom<?>, String, String>> notices =
-            new ArrayList<Trio<Atom<?>, String, String>>();
+      List<Triple<Atom<?>, String, String>> notices =
+            new ArrayList<Triple<Atom<?>, String, String>>();
       atom.addWatcher((a, oldValue, newValue) ->
-            notices.add(Trio.create(a, oldValue, newValue)));
+            notices.add(Triple.of(a, oldValue, newValue)));
       Function<String, String> twice = i -> i + i;
       
       Transaction.execute(t -> {
@@ -154,14 +154,14 @@ public class TransactionalAtomTest extends AbstractSynchronousAtomTest {
       assertEquals("ABCABC", atom.get());
       // watchers only get the total delta from before-transaction to committed-value
       assertEquals(1, notices.size());
-      assertEquals(Trio.create(atom,  "", "ABCABC"), notices.get(0));
+      assertEquals(Triple.of(atom,  "", "ABCABC"), notices.get(0));
    }
    
    @Test public void commute_inTransaction() {
       TransactionalAtom<Integer> atom = create(100);
-      List<Trio<Atom<?>, Integer, Integer>> notices =
-            new ArrayList<Trio<Atom<?>, Integer, Integer>>();
-      atom.addWatcher((a, oldValue, newValue) -> notices.add(Trio.create(a, oldValue, newValue)));
+      List<Triple<Atom<?>, Integer, Integer>> notices =
+            new ArrayList<Triple<Atom<?>, Integer, Integer>>();
+      atom.addWatcher((a, oldValue, newValue) -> notices.add(Triple.of(a, oldValue, newValue)));
       Function<Integer, Integer> twice = i -> i << 1;
       
       // explicit rollback cancels the future
@@ -198,7 +198,7 @@ public class TransactionalAtomTest extends AbstractSynchronousAtomTest {
       assertEquals(Integer.valueOf(400), atom.get());
       // got a notice this time
       assertEquals(1, notices.size());
-      assertEquals(Trio.create(atom, 100, 400), notices.get(0));
+      assertEquals(Triple.of(atom, 100, 400), notices.get(0));
    }
 
    @Test public void pin_inTransaction() throws Exception {

--- a/test/com/bluegosling/result/ResultTest.java
+++ b/test/com/bluegosling/result/ResultTest.java
@@ -24,7 +24,7 @@ import com.bluegosling.possible.Possible;
 import com.bluegosling.result.FailedResultException;
 import com.bluegosling.result.Result;
 import com.bluegosling.tuples.Pair;
-import com.bluegosling.tuples.Trio;
+import com.bluegosling.tuples.Triple;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 
@@ -327,15 +327,15 @@ public class ResultTest {
       Result<String, String> r1 = Result.ok("ok");
       Result<String, String> r2 = Result.ok("ko");
       
-      Pair<String, String> expected = Pair.create("ok", "ko");
-      Pair<String, String> other = Pair.create("foo", "bar");
+      Pair<String, String> expected = Pair.of("ok", "ko");
+      Pair<String, String> other = Pair.of("foo", "bar");
     
-      checkSuccess(r1.combineWith(r2, Pair::create), expected, other);
+      checkSuccess(r1.combineWith(r2, Pair::of), expected, other);
       
       Result<String, String> failed = Result.error("kaboom!");
       
-      checkError(failed.combineWith(r1, Pair::create), "kaboom!", "pow!", other);
-      checkError(r2.combineWith(failed, Pair::create), "kaboom!", "pow!", other);
+      checkError(failed.combineWith(r1, Pair::of), "kaboom!", "pow!", other);
+      checkError(r2.combineWith(failed, Pair::of), "kaboom!", "pow!", other);
    }
    
    @Test public void combineWith_3() {
@@ -343,15 +343,15 @@ public class ResultTest {
       Result<String, String> r2 = Result.ok("ko");
       Result<String, String> r3 = Result.ok("OK");
       
-      Trio<String, String, String> expected = Trio.create("ok", "ko", "OK");
-      Trio<String, String, String> other = Trio.create("foo", "bar", "baz");
+      Triple<String, String, String> expected = Triple.of("ok", "ko", "OK");
+      Triple<String, String, String> other = Triple.of("foo", "bar", "baz");
     
-      checkSuccess(r1.combineWith(r2, r3, Trio::create), expected, other);
+      checkSuccess(r1.combineWith(r2, r3, Triple::of), expected, other);
       
       Result<String, String> failed = Result.error("kaboom!");
       
-      checkError(failed.combineWith(r1, r2, Trio::create), "kaboom!", "pow!", other);
-      checkError(r2.combineWith(r3, failed, Trio::create), "kaboom!", "pow!", other);
+      checkError(failed.combineWith(r1, r2, Triple::of), "kaboom!", "pow!", other);
+      checkError(r2.combineWith(r3, failed, Triple::of), "kaboom!", "pow!", other);
    }
    
    @Test public void successfulOnly() {

--- a/test/com/bluegosling/tuples/EmptyTest.java
+++ b/test/com/bluegosling/tuples/EmptyTest.java
@@ -57,8 +57,8 @@ public class EmptyTest {
    
    @Test public void equals() {
       assertTrue(e.equals(e));
-      assertTrue(e.equals(Unit.create("a").removeFirst()));
-      assertFalse(e.equals(Unit.create("a")));
+      assertTrue(e.equals(Single.of("a").removeFirst()));
+      assertFalse(e.equals(Single.of("a")));
       assertFalse(e.equals(Collections.emptyList()));
    }
    
@@ -69,8 +69,8 @@ public class EmptyTest {
    // accessors / mutators
    
    @Test public void addAndInsert() {
-      Unit<String> u = e.add("a");
-      assertEquals(Unit.create("a"), u);
+      Single<String> u = e.add("a");
+      assertEquals(Single.of("a"), u);
       assertEquals(u, e.insertFirst("a"));
    }
    

--- a/test/com/bluegosling/tuples/NTupleTest.java
+++ b/test/com/bluegosling/tuples/NTupleTest.java
@@ -122,14 +122,14 @@ public class NTupleTest {
             NTuple.create(1, 42.0, "foobar", 0x1234L, "baz", 2, 4, 8, 16, "ABC", "XYZ")
                   .insertFirst("a")));
       assertTrue(n.equals(
-            Quintet.create(1, 42.0, "foobar", 0x1234L, "baz").insertFirst("a")
+            Quintuple.of(1, 42.0, "foobar", 0x1234L, "baz").insertFirst("a")
                   .add(2).add(4).add(8).add(16).add("ABC").add("XYZ")));
       assertFalse(n.equals(Empty.INSTANCE));
-      assertFalse(n.equals(Unit.create("a")));
-      assertFalse(n.equals(Pair.create("a", 1)));
-      assertFalse(n.equals(Trio.create("a", 1, 42.0)));
-      assertFalse(n.equals(Quartet.create("a", 1, 42.0, "baz")));
-      assertFalse(n.equals(Quintet.create("a", 1, 42.0, "foobar", 0x1234L)));
+      assertFalse(n.equals(Single.of("a")));
+      assertFalse(n.equals(Pair.of("a", 1)));
+      assertFalse(n.equals(Triple.of("a", 1, 42.0)));
+      assertFalse(n.equals(Quadruple.of("a", 1, 42.0, "baz")));
+      assertFalse(n.equals(Quintuple.of("a", 1, 42.0, "foobar", 0x1234L)));
       assertFalse(n.equals(NTuple.create("a", 1, 42.0, "foobar", 0x1234L, "baz")));
       assertFalse(n.equals(
             NTuple.create("a", 1, 42.0, "foobar", 0x1234L, "baz", 2, 4, 8, 16, "ABC", "DEF")));
@@ -193,24 +193,24 @@ public class NTupleTest {
    @Test public void remove_sixItems() {
       NTuple<String, Integer, Double, String, Long> n6 =
             NTuple.create("a", 1, 42.0, "foobar", 0x1234L, "baz");
-      assertEquals(Quintet.create(1, 42.0, "foobar", 0x1234L, "baz"), n6.removeFirst());
-      assertEquals(Quintet.create("a", 42.0, "foobar", 0x1234L, "baz"), n6.removeSecond());
-      assertEquals(Quintet.create("a", 1, "foobar", 0x1234L, "baz"), n6.removeThird());
-      assertEquals(Quintet.create("a", 1, 42.0, 0x1234L, "baz"), n6.removeFourth());
-      assertEquals(Quintet.create("a", 1, 42.0, "foobar", "baz"), n6.removeFifth());
-      // result has 5 items so should be instance of Quintet
-      assertSame(Quintet.class, n6.removeFirst().getClass());
-      assertSame(Quintet.class, n6.removeSecond().getClass());
-      assertSame(Quintet.class, n6.removeThird().getClass());
-      assertSame(Quintet.class, n6.removeFourth().getClass());
-      assertSame(Quintet.class, n6.removeFifth().getClass());
+      assertEquals(Quintuple.of(1, 42.0, "foobar", 0x1234L, "baz"), n6.removeFirst());
+      assertEquals(Quintuple.of("a", 42.0, "foobar", 0x1234L, "baz"), n6.removeSecond());
+      assertEquals(Quintuple.of("a", 1, "foobar", 0x1234L, "baz"), n6.removeThird());
+      assertEquals(Quintuple.of("a", 1, 42.0, 0x1234L, "baz"), n6.removeFourth());
+      assertEquals(Quintuple.of("a", 1, 42.0, "foobar", "baz"), n6.removeFifth());
+      // result has 5 items so should be instance of Quintuple
+      assertSame(Quintuple.class, n6.removeFirst().getClass());
+      assertSame(Quintuple.class, n6.removeSecond().getClass());
+      assertSame(Quintuple.class, n6.removeThird().getClass());
+      assertSame(Quintuple.class, n6.removeFourth().getClass());
+      assertSame(Quintuple.class, n6.removeFifth().getClass());
       //random access
-      assertEquals(Quintet.create(1, 42.0, "foobar", 0x1234L, "baz"), n6.remove(0));
-      assertEquals(Quintet.create("a", 1, "foobar", 0x1234L, "baz"), n6.remove(2));
-      assertEquals(Quintet.create("a", 1, 42.0, "foobar", 0x1234L), n6.remove(5));
-      assertSame(Quintet.class, n6.remove(0).getClass());
-      assertSame(Quintet.class, n6.remove(2).getClass());
-      assertSame(Quintet.class, n6.remove(5).getClass());
+      assertEquals(Quintuple.of(1, 42.0, "foobar", 0x1234L, "baz"), n6.remove(0));
+      assertEquals(Quintuple.of("a", 1, "foobar", 0x1234L, "baz"), n6.remove(2));
+      assertEquals(Quintuple.of("a", 1, 42.0, "foobar", 0x1234L), n6.remove(5));
+      assertSame(Quintuple.class, n6.remove(0).getClass());
+      assertSame(Quintuple.class, n6.remove(2).getClass());
+      assertSame(Quintuple.class, n6.remove(5).getClass());
    }
    
    @Test public void remove_moreThanSixItems() {

--- a/test/com/bluegosling/tuples/PairTest.java
+++ b/test/com/bluegosling/tuples/PairTest.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
  */
 public class PairTest {
    
-   private final Pair<String, Integer> p = Pair.create("a", 1);
+   private final Pair<String, Integer> p = Pair.of("a", 1);
    
    // Collection-like operations
    
@@ -36,8 +36,8 @@ public class PairTest {
       assertFalse(p.contains(new Object()));
       assertTrue(p.contains("a"));
       assertTrue(p.contains(1));
-      assertTrue(Pair.create("a", null).contains(null));
-      assertTrue(Pair.create(null, "a").contains(null));
+      assertTrue(Pair.of("a", null).contains(null));
+      assertTrue(Pair.of(null, "a").contains(null));
    }
    
    @Test public void isEmpty() {
@@ -73,12 +73,12 @@ public class PairTest {
    
    @Test public void equals() {
       assertTrue(p.equals(p));
-      assertTrue(p.equals(Pair.create("a", 1)));
-      assertTrue(p.equals(Trio.create("a", "b", 1).removeSecond()));
-      assertTrue(p.equals(Unit.create(1).insertFirst("a")));
+      assertTrue(p.equals(Pair.of("a", 1)));
+      assertTrue(p.equals(Triple.of("a", "b", 1).removeSecond()));
+      assertTrue(p.equals(Single.of(1).insertFirst("a")));
       assertFalse(p.equals(Empty.INSTANCE));
-      assertFalse(p.equals(Unit.create("a")));
-      assertFalse(p.equals(Pair.create("a", "b")));
+      assertFalse(p.equals(Single.of("a")));
+      assertFalse(p.equals(Pair.of("a", "b")));
       assertFalse(p.equals(Arrays.<Object>asList("a", 1)));
    }
    
@@ -94,16 +94,16 @@ public class PairTest {
    }
    
    @Test public void addAndInsert() {
-      Trio<String, Integer, Double> t = p.add(42.0);
-      assertEquals(Trio.create("a", 1, 42.0), t);
+      Triple<String, Integer, Double> t = p.add(42.0);
+      assertEquals(Triple.of("a", 1, 42.0), t);
       assertEquals(t, p.insertThird(42.0));
-      assertEquals(Trio.create(42.0, "a", 1), p.insertFirst(42.0));
-      assertEquals(Trio.create("a", 42.0, 1), p.insertSecond(42.0));
+      assertEquals(Triple.of(42.0, "a", 1), p.insertFirst(42.0));
+      assertEquals(Triple.of("a", 42.0, 1), p.insertSecond(42.0));
    }
    
    @Test public void remove() {
-      assertEquals(Unit.create(1), p.removeFirst());
-      assertEquals(Unit.create("a"), p.removeSecond());
+      assertEquals(Single.of(1), p.removeFirst());
+      assertEquals(Single.of("a"), p.removeSecond());
    }
    
    @Test public void transform() {
@@ -113,9 +113,9 @@ public class PairTest {
          }
       };
       
-      assertEquals(Pair.create("abcdefg", "abcdefg"), p.transformAll(f));
-      assertEquals(Pair.create("abcdefg", 1), p.transformFirst(f));
-      assertEquals(Pair.create("a", "abcdefg"), p.transformSecond(f));
+      assertEquals(Pair.of("abcdefg", "abcdefg"), p.transformAll(f));
+      assertEquals(Pair.of("abcdefg", 1), p.transformFirst(f));
+      assertEquals(Pair.of("a", "abcdefg"), p.transformSecond(f));
    }
    
    // serialization
@@ -132,19 +132,19 @@ public class PairTest {
    // separate, combine
    
    @Test public void separate() {
-      assertEquals(Pair.create(Collections.emptyList(), Collections.emptyList()),
+      assertEquals(Pair.of(Collections.emptyList(), Collections.emptyList()),
             Pair.separate(Collections.<Pair<Integer, String>>emptyList()));
 
       List<Pair<Integer, String>> pairs =
-            Arrays.asList(Pair.create(1, "a"), Pair.create(2, "b"), Pair.create(3, "c"));
-      assertEquals(Pair.create(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c")),
+            Arrays.asList(Pair.of(1, "a"), Pair.of(2, "b"), Pair.of(3, "c"));
+      assertEquals(Pair.of(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c")),
             Pair.separate(pairs));
    }
 
    private <A, B> void assertCombinedEquals(List<Pair<A, B>> expectedPairs,
          Collection<? extends A> a, Collection<? extends B> b) {
       assertEquals(expectedPairs, Pair.combine(a, b));
-      assertEquals(expectedPairs, Pair.combine(Pair.create(a, b)));
+      assertEquals(expectedPairs, Pair.combine(Pair.of(a, b)));
    }
    
    @Test public void combine() {
@@ -152,7 +152,7 @@ public class PairTest {
             Collections.<Integer>emptyList(), Collections.<String>emptyList());
 
       assertCombinedEquals(
-            Arrays.asList(Pair.create(1, "a"), Pair.create(2, "b"), Pair.create(3, "c")),
+            Arrays.asList(Pair.of(1, "a"), Pair.of(2, "b"), Pair.of(3, "c")),
             Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"));
    }
 
@@ -164,7 +164,7 @@ public class PairTest {
       }
 
       try {
-         Pair.combine(Pair.create(a, b));
+         Pair.combine(Pair.of(a, b));
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }

--- a/test/com/bluegosling/tuples/QuadrupleTest.java
+++ b/test/com/bluegosling/tuples/QuadrupleTest.java
@@ -20,13 +20,13 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Test cases for {@link Quartet}.
+ * Test cases for {@link Quadruple}.
  *
  * @author Joshua Humphries (jhumphries131@gmail.com)
  */
-public class QuartetTest {
+public class QuadrupleTest {
 
-   private final Quartet<String, Integer, Double, String> q = Quartet.create("a", 1, 42.0, "foobar");
+   private final Quadruple<String, Integer, Double, String> q = Quadruple.of("a", 1, 42.0, "foobar");
 
    // Collection-like operations
    
@@ -38,10 +38,10 @@ public class QuartetTest {
       assertTrue(q.contains(1));
       assertTrue(q.contains(42.0));
       assertTrue(q.contains("foobar"));
-      assertTrue(Quartet.create("a", 1, 42.0, null).contains(null));
-      assertTrue(Quartet.create("a", 1, null, 42.0).contains(null));
-      assertTrue(Quartet.create("a", null, 1, 42.0).contains(null));
-      assertTrue(Quartet.create(null, "a", 1, 42.0).contains(null));
+      assertTrue(Quadruple.of("a", 1, 42.0, null).contains(null));
+      assertTrue(Quadruple.of("a", 1, null, 42.0).contains(null));
+      assertTrue(Quadruple.of("a", null, 1, 42.0).contains(null));
+      assertTrue(Quadruple.of(null, "a", 1, 42.0).contains(null));
    }
    
    @Test public void isEmpty() {
@@ -83,14 +83,14 @@ public class QuartetTest {
    
    @Test public void equals() {
       assertTrue(q.equals(q));
-      assertTrue(q.equals(Quartet.create("a", 1, 42.0, "foobar")));
-      assertTrue(q.equals(Quintet.create("XYZ", "a", 1, 42.0, "foobar").removeFirst()));
-      assertTrue(q.equals(Trio.create(1, 42.0, "foobar").insertFirst("a")));
+      assertTrue(q.equals(Quadruple.of("a", 1, 42.0, "foobar")));
+      assertTrue(q.equals(Quintuple.of("XYZ", "a", 1, 42.0, "foobar").removeFirst()));
+      assertTrue(q.equals(Triple.of(1, 42.0, "foobar").insertFirst("a")));
       assertFalse(q.equals(Empty.INSTANCE));
-      assertFalse(q.equals(Unit.create("a")));
-      assertFalse(q.equals(Pair.create("a", 1)));
-      assertFalse(q.equals(Trio.create("a", 1, 42.0)));
-      assertFalse(q.equals(Quartet.create("a", 1, 42.0, "baz")));
+      assertFalse(q.equals(Single.of("a")));
+      assertFalse(q.equals(Pair.of("a", 1)));
+      assertFalse(q.equals(Triple.of("a", 1, 42.0)));
+      assertFalse(q.equals(Quadruple.of("a", 1, 42.0, "baz")));
       assertFalse(q.equals(Arrays.<Object>asList("a", 1, 42.0, "foobar")));
    }
    
@@ -108,20 +108,20 @@ public class QuartetTest {
    }
    
    @Test public void addAndInsert() {
-      Quintet<String, Integer, Double, String, Long> q5 = q.add(0x1234L);
-      assertEquals(Quintet.create("a", 1, 42.0, "foobar", 0x1234L), q5);
+      Quintuple<String, Integer, Double, String, Long> q5 = q.add(0x1234L);
+      assertEquals(Quintuple.of("a", 1, 42.0, "foobar", 0x1234L), q5);
       assertEquals(q5, q.insertFifth(0x1234L));
-      assertEquals(Quintet.create(0x1234L, "a", 1, 42.0, "foobar"), q.insertFirst(0x1234L));
-      assertEquals(Quintet.create("a", 0x1234L, 1, 42.0, "foobar"), q.insertSecond(0x1234L));
-      assertEquals(Quintet.create("a", 1, 0x1234L, 42.0, "foobar"), q.insertThird(0x1234L));
-      assertEquals(Quintet.create("a", 1, 42.0, 0x1234L, "foobar"), q.insertFourth(0x1234L));
+      assertEquals(Quintuple.of(0x1234L, "a", 1, 42.0, "foobar"), q.insertFirst(0x1234L));
+      assertEquals(Quintuple.of("a", 0x1234L, 1, 42.0, "foobar"), q.insertSecond(0x1234L));
+      assertEquals(Quintuple.of("a", 1, 0x1234L, 42.0, "foobar"), q.insertThird(0x1234L));
+      assertEquals(Quintuple.of("a", 1, 42.0, 0x1234L, "foobar"), q.insertFourth(0x1234L));
    }
    
    @Test public void remove() {
-      assertEquals(Trio.create(1, 42.0, "foobar"), q.removeFirst());
-      assertEquals(Trio.create("a", 42.0, "foobar"), q.removeSecond());
-      assertEquals(Trio.create("a", 1, "foobar"), q.removeThird());
-      assertEquals(Trio.create("a", 1, 42.0), q.removeFourth());
+      assertEquals(Triple.of(1, 42.0, "foobar"), q.removeFirst());
+      assertEquals(Triple.of("a", 42.0, "foobar"), q.removeSecond());
+      assertEquals(Triple.of("a", 1, "foobar"), q.removeThird());
+      assertEquals(Triple.of("a", 1, 42.0), q.removeFourth());
    }
    
    @Test public void transform() {
@@ -131,11 +131,11 @@ public class QuartetTest {
          }
       };
       
-      assertEquals(Quartet.create("abcdefg", "abcdefg", "abcdefg", "abcdefg"), q.transformAll(f));
-      assertEquals(Quartet.create("abcdefg", 1, 42.0, "foobar"), q.transformFirst(f));
-      assertEquals(Quartet.create("a", "abcdefg", 42.0, "foobar"), q.transformSecond(f));
-      assertEquals(Quartet.create("a", 1, "abcdefg", "foobar"), q.transformThird(f));
-      assertEquals(Quartet.create("a", 1, 42.0, "abcdefg"), q.transformFourth(f));
+      assertEquals(Quadruple.of("abcdefg", "abcdefg", "abcdefg", "abcdefg"), q.transformAll(f));
+      assertEquals(Quadruple.of("abcdefg", 1, 42.0, "foobar"), q.transformFirst(f));
+      assertEquals(Quadruple.of("a", "abcdefg", 42.0, "foobar"), q.transformSecond(f));
+      assertEquals(Quadruple.of("a", 1, "abcdefg", "foobar"), q.transformThird(f));
+      assertEquals(Quadruple.of("a", 1, 42.0, "abcdefg"), q.transformFourth(f));
    }
    
    // serialization
@@ -144,8 +144,8 @@ public class QuartetTest {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       new ObjectOutputStream(bos).writeObject(q);
       ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-      Quartet<?, ?, ?, ?> deserialized =
-            (Quartet<?, ?, ?, ?>) new ObjectInputStream(bis).readObject();
+      Quadruple<?, ?, ?, ?> deserialized =
+            (Quadruple<?, ?, ?, ?>) new ObjectInputStream(bis).readObject();
       
       assertEquals(q, deserialized);
    }
@@ -154,34 +154,34 @@ public class QuartetTest {
    
    @Test public void separate() {
       assertEquals(
-            Quartet.create(Collections.emptyList(), Collections.emptyList(),
+            Quadruple.of(Collections.emptyList(), Collections.emptyList(),
                   Collections.emptyList(), Collections.emptyList()),
-            Quartet.separate(Collections.<Quartet<Integer, String, Double, Boolean>>emptyList()));
+            Quadruple.separate(Collections.<Quadruple<Integer, String, Double, Boolean>>emptyList()));
 
-      List<Quartet<Integer, String, Double, Boolean>> quartets =
-            Arrays.asList(Quartet.create(1, "a", 101.0, true), Quartet.create(2, "b", 222.0, false),
-                  Quartet.create(3, "c", 330.3, true));
+      List<Quadruple<Integer, String, Double, Boolean>> quartets =
+            Arrays.asList(Quadruple.of(1, "a", 101.0, true), Quadruple.of(2, "b", 222.0, false),
+                  Quadruple.of(3, "c", 330.3, true));
       assertEquals(
-            Quartet.create(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
+            Quadruple.of(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
                   Arrays.asList(101.0, 222.0, 330.3), Arrays.asList(true, false, true)),
-            Quartet.separate(quartets));
+            Quadruple.separate(quartets));
    }
 
-   private <A, B, C, D> void assertCombinedEquals(List<Quartet<A, B, C, D>> expectedQuartets,
+   private <A, B, C, D> void assertCombinedEquals(List<Quadruple<A, B, C, D>> expectedQuartets,
          Collection<? extends A> a, Collection<? extends B> b, Collection<? extends C> c,
          Collection<? extends D> d) {
-      assertEquals(expectedQuartets, Quartet.combine(a, b, c, d));
-      assertEquals(expectedQuartets, Quartet.combine(Quartet.create(a, b, c, d)));
+      assertEquals(expectedQuartets, Quadruple.combine(a, b, c, d));
+      assertEquals(expectedQuartets, Quadruple.combine(Quadruple.of(a, b, c, d)));
    }
    
    @Test public void combine() {
-      assertCombinedEquals(Collections.<Quartet<Integer, String, Double, Boolean>>emptyList(),
+      assertCombinedEquals(Collections.<Quadruple<Integer, String, Double, Boolean>>emptyList(),
             Collections.<Integer>emptyList(), Collections.<String>emptySet(),
             Collections.<Double>emptyList(), Collections.<Boolean>emptySet());
 
       assertCombinedEquals(
-            Arrays.asList(Quartet.create(1, "a", 101.0, true), Quartet.create(2, "b", 222.0, false),
-                  Quartet.create(3, "c", 330.3, true)),
+            Arrays.asList(Quadruple.of(1, "a", 101.0, true), Quadruple.of(2, "b", 222.0, false),
+                  Quadruple.of(3, "c", 330.3, true)),
             Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
             Arrays.asList(101.0, 222.0, 330.3), Arrays.asList(true, false, true));
    }
@@ -189,13 +189,13 @@ public class QuartetTest {
    private void assertCombineFails(Collection<?> a, Collection<?> b, Collection<?> c,
          Collection<?> d) {
       try {
-         Quartet.combine(a, b, c, d);
+         Quadruple.combine(a, b, c, d);
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }
 
       try {
-         Quartet.combine(Quartet.create(a, b, c, d));
+         Quadruple.combine(Quadruple.of(a, b, c, d));
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }

--- a/test/com/bluegosling/tuples/QuintupleTest.java
+++ b/test/com/bluegosling/tuples/QuintupleTest.java
@@ -20,14 +20,14 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Test cases for {@link Quintet}.
+ * Test cases for {@link Quintuple}.
  *
  * @author Joshua Humphries (jhumphries131@gmail.com)
  */
-public class QuintetTest {
+public class QuintupleTest {
 
-   private final Quintet<String, Integer, Double, String, Long> q =
-         Quintet.create("a", 1, 42.0, "foobar", 0x1234L);
+   private final Quintuple<String, Integer, Double, String, Long> q =
+         Quintuple.of("a", 1, 42.0, "foobar", 0x1234L);
 
    // Collection-like operations
    
@@ -40,11 +40,11 @@ public class QuintetTest {
       assertTrue(q.contains(42.0));
       assertTrue(q.contains("foobar"));
       assertTrue(q.contains(0x1234L));
-      assertTrue(Quintet.create("a", 1, 42.0, "foobar", null).contains(null));
-      assertTrue(Quintet.create("a", 1, 42.0, null, "foobar").contains(null));
-      assertTrue(Quintet.create("a", 1, null, 42.0, "foobar").contains(null));
-      assertTrue(Quintet.create("a", null, 1, 42.0, "foobar").contains(null));
-      assertTrue(Quintet.create(null, "a", 1, 42.0, "foobar").contains(null));
+      assertTrue(Quintuple.of("a", 1, 42.0, "foobar", null).contains(null));
+      assertTrue(Quintuple.of("a", 1, 42.0, null, "foobar").contains(null));
+      assertTrue(Quintuple.of("a", 1, null, 42.0, "foobar").contains(null));
+      assertTrue(Quintuple.of("a", null, 1, 42.0, "foobar").contains(null));
+      assertTrue(Quintuple.of(null, "a", 1, 42.0, "foobar").contains(null));
    }
    
    @Test public void isEmpty() {
@@ -89,15 +89,15 @@ public class QuintetTest {
    
    @Test public void equals() {
       assertTrue(q.equals(q));
-      assertTrue(q.equals(Quintet.create("a", 1, 42.0, "foobar", 0x1234L)));
+      assertTrue(q.equals(Quintuple.of("a", 1, 42.0, "foobar", 0x1234L)));
       assertTrue(q.equals(NTuple.create("XYZ", "a", 1, 42.0, "foobar", 0x1234L).removeFirst()));
-      assertTrue(q.equals(Quartet.create(1, 42.0, "foobar", 0x1234L).insertFirst("a")));
+      assertTrue(q.equals(Quadruple.of(1, 42.0, "foobar", 0x1234L).insertFirst("a")));
       assertFalse(q.equals(Empty.INSTANCE));
-      assertFalse(q.equals(Unit.create("a")));
-      assertFalse(q.equals(Pair.create("a", 1)));
-      assertFalse(q.equals(Trio.create("a", 1, 42.0)));
-      assertFalse(q.equals(Quartet.create("a", 1, 42.0, "baz")));
-      assertFalse(q.equals(Quintet.create("a", 1, 42.0, "foobar", 0x2222L)));
+      assertFalse(q.equals(Single.of("a")));
+      assertFalse(q.equals(Pair.of("a", 1)));
+      assertFalse(q.equals(Triple.of("a", 1, 42.0)));
+      assertFalse(q.equals(Quadruple.of("a", 1, 42.0, "baz")));
+      assertFalse(q.equals(Quintuple.of("a", 1, 42.0, "foobar", 0x2222L)));
       assertFalse(q.equals(Arrays.<Object>asList("a", 1, 42.0, "foobar", 0x1234L)));
    }
    
@@ -125,11 +125,11 @@ public class QuintetTest {
    }
    
    @Test public void remove() {
-      assertEquals(Quartet.create(1, 42.0, "foobar", 0x1234L), q.removeFirst());
-      assertEquals(Quartet.create("a", 42.0, "foobar", 0x1234L), q.removeSecond());
-      assertEquals(Quartet.create("a", 1, "foobar", 0x1234L), q.removeThird());
-      assertEquals(Quartet.create("a", 1, 42.0, 0x1234L), q.removeFourth());
-      assertEquals(Quartet.create("a", 1, 42.0, "foobar"), q.removeFifth());
+      assertEquals(Quadruple.of(1, 42.0, "foobar", 0x1234L), q.removeFirst());
+      assertEquals(Quadruple.of("a", 42.0, "foobar", 0x1234L), q.removeSecond());
+      assertEquals(Quadruple.of("a", 1, "foobar", 0x1234L), q.removeThird());
+      assertEquals(Quadruple.of("a", 1, 42.0, 0x1234L), q.removeFourth());
+      assertEquals(Quadruple.of("a", 1, 42.0, "foobar"), q.removeFifth());
    }
    
    @Test public void transform() {
@@ -139,13 +139,13 @@ public class QuintetTest {
          }
       };
       
-      assertEquals(Quintet.create("abcdefg", "abcdefg", "abcdefg", "abcdefg", "abcdefg"),
+      assertEquals(Quintuple.of("abcdefg", "abcdefg", "abcdefg", "abcdefg", "abcdefg"),
             q.transformAll(f));
-      assertEquals(Quintet.create("abcdefg", 1, 42.0, "foobar", 0x1234L), q.transformFirst(f));
-      assertEquals(Quintet.create("a", "abcdefg", 42.0, "foobar", 0x1234L), q.transformSecond(f));
-      assertEquals(Quintet.create("a", 1, "abcdefg", "foobar", 0x1234L), q.transformThird(f));
-      assertEquals(Quintet.create("a", 1, 42.0, "abcdefg", 0x1234L), q.transformFourth(f));
-      assertEquals(Quintet.create("a", 1, 42.0, "foobar", "abcdefg"), q.transformFifth(f));
+      assertEquals(Quintuple.of("abcdefg", 1, 42.0, "foobar", 0x1234L), q.transformFirst(f));
+      assertEquals(Quintuple.of("a", "abcdefg", 42.0, "foobar", 0x1234L), q.transformSecond(f));
+      assertEquals(Quintuple.of("a", 1, "abcdefg", "foobar", 0x1234L), q.transformThird(f));
+      assertEquals(Quintuple.of("a", 1, 42.0, "abcdefg", 0x1234L), q.transformFourth(f));
+      assertEquals(Quintuple.of("a", 1, 42.0, "foobar", "abcdefg"), q.transformFifth(f));
    }
    
    // serialization
@@ -154,8 +154,8 @@ public class QuintetTest {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       new ObjectOutputStream(bos).writeObject(q);
       ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-      Quintet<?, ?, ?, ?, ?> deserialized =
-            (Quintet<?, ?, ?, ?, ?>) new ObjectInputStream(bis).readObject();
+      Quintuple<?, ?, ?, ?, ?> deserialized =
+            (Quintuple<?, ?, ?, ?, ?>) new ObjectInputStream(bis).readObject();
       
       assertEquals(q, deserialized);
    }
@@ -164,39 +164,39 @@ public class QuintetTest {
    
    @Test public void separate() {
       assertEquals(
-            Quintet.create(Collections.emptyList(), Collections.emptyList(),
+            Quintuple.of(Collections.emptyList(), Collections.emptyList(),
                   Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
-            Quintet.separate(
-                  Collections.<Quintet<Integer, String, Double, Boolean, Float>>emptyList()));
+            Quintuple.separate(
+                  Collections.<Quintuple<Integer, String, Double, Boolean, Float>>emptyList()));
 
-      List<Quintet<Integer, String, Double, Boolean, Float>> quintets =
-            Arrays.asList(Quintet.create(1, "a", 101.0, true, 321f),
-                  Quintet.create(2, "b", 222.0, false, 432f),
-                  Quintet.create(3, "c", 330.3, true, 543f));
+      List<Quintuple<Integer, String, Double, Boolean, Float>> quintets =
+            Arrays.asList(Quintuple.of(1, "a", 101.0, true, 321f),
+                  Quintuple.of(2, "b", 222.0, false, 432f),
+                  Quintuple.of(3, "c", 330.3, true, 543f));
       assertEquals(
-            Quintet.create(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
+            Quintuple.of(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
                   Arrays.asList(101.0, 222.0, 330.3), Arrays.asList(true, false, true),
                   Arrays.asList(321f, 432f, 543f)),
-            Quintet.separate(quintets));
+            Quintuple.separate(quintets));
    }
 
-   private <A, B, C, D, E> void assertCombinedEquals(List<Quintet<A, B, C, D, E>> expectedQuintets,
+   private <A, B, C, D, E> void assertCombinedEquals(List<Quintuple<A, B, C, D, E>> expectedQuintets,
          Collection<? extends A> a, Collection<? extends B> b, Collection<? extends C> c,
          Collection<? extends D> d, Collection<? extends E> e) {
-      assertEquals(expectedQuintets, Quintet.combine(a, b, c, d, e));
-      assertEquals(expectedQuintets, Quintet.combine(Quintet.create(a, b, c, d, e)));
+      assertEquals(expectedQuintets, Quintuple.combine(a, b, c, d, e));
+      assertEquals(expectedQuintets, Quintuple.combine(Quintuple.of(a, b, c, d, e)));
    }
    
    @Test public void combine() {
-      assertCombinedEquals(Collections.<Quintet<Integer, String, Double, Boolean, Float>>emptyList(),
+      assertCombinedEquals(Collections.<Quintuple<Integer, String, Double, Boolean, Float>>emptyList(),
             Collections.<Integer>emptyList(), Collections.<String>emptySet(),
             Collections.<Double>emptyList(), Collections.<Boolean>emptySet(),
             Collections.<Float>emptyList());
 
       assertCombinedEquals(
-            Arrays.asList(Quintet.create(1, "a", 101.0, true, 321f),
-                  Quintet.create(2, "b", 222.0, false, 432f),
-                  Quintet.create(3, "c", 330.3, true, 543f)),
+            Arrays.asList(Quintuple.of(1, "a", 101.0, true, 321f),
+                  Quintuple.of(2, "b", 222.0, false, 432f),
+                  Quintuple.of(3, "c", 330.3, true, 543f)),
             Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
             Arrays.asList(101.0, 222.0, 330.3), Arrays.asList(true, false, true),
             Arrays.asList(321f, 432f, 543f));
@@ -205,13 +205,13 @@ public class QuintetTest {
    private void assertCombineFails(Collection<?> a, Collection<?> b, Collection<?> c,
          Collection<?> d, Collection<?> e) {
       try {
-         Quintet.combine(a, b, c, d, e);
+         Quintuple.combine(a, b, c, d, e);
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }
 
       try {
-         Quintet.combine(Quintet.create(a, b, c, d, e));
+         Quintuple.combine(Quintuple.of(a, b, c, d, e));
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }

--- a/test/com/bluegosling/tuples/SingleTest.java
+++ b/test/com/bluegosling/tuples/SingleTest.java
@@ -18,13 +18,13 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Test cases from {@link Unit}.
+ * Test cases from {@link Single}.
  *
  * @author Joshua Humphries (jhumphries131@gmail.com)
  */
-public class UnitTest {
+public class SingleTest {
 
-   private final Unit<String> u = Unit.create("a");
+   private final Single<String> u = Single.of("a");
 
    // Collection-like operations
    
@@ -33,7 +33,7 @@ public class UnitTest {
       assertFalse(u.contains("b"));
       assertFalse(u.contains(new Object()));
       assertTrue(u.contains("a"));
-      assertTrue(Unit.create(null).contains(null));
+      assertTrue(Single.of(null).contains(null));
    }
    
    @Test public void isEmpty() {
@@ -66,12 +66,12 @@ public class UnitTest {
    
    @Test public void equals() {
       assertTrue(u.equals(u));
-      assertTrue(u.equals(Unit.create("a")));
-      assertTrue(u.equals(Pair.create("a", "b").removeSecond()));
+      assertTrue(u.equals(Single.of("a")));
+      assertTrue(u.equals(Pair.of("a", "b").removeSecond()));
       assertTrue(u.equals(Empty.INSTANCE.add("a")));
       assertFalse(u.equals(Empty.INSTANCE));
-      assertFalse(u.equals(Unit.create("b")));
-      assertFalse(u.equals(Pair.create("a", "b")));
+      assertFalse(u.equals(Single.of("b")));
+      assertFalse(u.equals(Pair.of("a", "b")));
       assertFalse(u.equals(Collections.singletonList("a")));
    }
    
@@ -87,9 +87,9 @@ public class UnitTest {
    
    @Test public void addAndInsert() {
       Pair<String, Integer> p = u.add(1);
-      assertEquals(Pair.create("a", 1), p);
+      assertEquals(Pair.of("a", 1), p);
       assertEquals(p, u.insertSecond(1));
-      assertEquals(Pair.create(42.0, "a"), u.insertFirst(42.0));
+      assertEquals(Pair.of(42.0, "a"), u.insertFirst(42.0));
    }
    
    @Test public void remove() {
@@ -103,8 +103,8 @@ public class UnitTest {
          }
       };
       
-      assertEquals(Unit.create("abcdefg"), u.transformAll(f));
-      assertEquals(Unit.create("abcdefg"), u.transformFirst(f));
+      assertEquals(Single.of("abcdefg"), u.transformAll(f));
+      assertEquals(Single.of("abcdefg"), u.transformFirst(f));
    }
    
    // serialization
@@ -113,7 +113,7 @@ public class UnitTest {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       new ObjectOutputStream(bos).writeObject(u);
       ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-      Unit<?> deserialized = (Unit<?>) new ObjectInputStream(bis).readObject();
+      Single<?> deserialized = (Single<?>) new ObjectInputStream(bis).readObject();
       
       assertEquals(u, deserialized);
    }
@@ -121,16 +121,16 @@ public class UnitTest {
    // extract, enclose
    
    @Test public void extract() {
-      assertEquals(Collections.emptyList(), Unit.extract(Collections.<Unit<String>>emptyList()));
+      assertEquals(Collections.emptyList(), Single.extract(Collections.<Single<String>>emptyList()));
 
-      List<Unit<Integer>> units = Arrays.asList(Unit.create(1), Unit.create(2), Unit.create(3));
-      assertEquals(Arrays.asList(1, 2, 3), Unit.extract(units));
+      List<Single<Integer>> units = Arrays.asList(Single.of(1), Single.of(2), Single.of(3));
+      assertEquals(Arrays.asList(1, 2, 3), Single.extract(units));
    }
 
    @Test public void enclose() {
-      assertEquals(Collections.emptyList(), Unit.enclose(Collections.<String>emptyList()));
+      assertEquals(Collections.emptyList(), Single.enclose(Collections.<String>emptyList()));
 
-      List<Unit<Integer>> units = Arrays.asList(Unit.create(1), Unit.create(2), Unit.create(3));
-      assertEquals(units, Unit.enclose(Arrays.asList(1, 2, 3)));
+      List<Single<Integer>> units = Arrays.asList(Single.of(1), Single.of(2), Single.of(3));
+      assertEquals(units, Single.enclose(Arrays.asList(1, 2, 3)));
    }
 }

--- a/test/com/bluegosling/tuples/TripleTest.java
+++ b/test/com/bluegosling/tuples/TripleTest.java
@@ -20,13 +20,13 @@ import java.util.List;
 import java.util.function.Function;
 
 /**
- * Test cases for {@link Trio}.
+ * Test cases for {@link Triple}.
  *
  * @author Joshua Humphries (jhumphries131@gmail.com)
  */
-public class TrioTest {
+public class TripleTest {
 
-   private final Trio<String, Integer, Double> t = Trio.create("a", 1, 42.0);
+   private final Triple<String, Integer, Double> t = Triple.of("a", 1, 42.0);
 
    // Collection-like operations
    
@@ -37,9 +37,9 @@ public class TrioTest {
       assertTrue(t.contains("a"));
       assertTrue(t.contains(1));
       assertTrue(t.contains(42.0));
-      assertTrue(Trio.create("a", 1, null).contains(null));
-      assertTrue(Trio.create("a", null, 1).contains(null));
-      assertTrue(Trio.create(null, "a", 1).contains(null));
+      assertTrue(Triple.of("a", 1, null).contains(null));
+      assertTrue(Triple.of("a", null, 1).contains(null));
+      assertTrue(Triple.of(null, "a", 1).contains(null));
    }
    
    @Test public void isEmpty() {
@@ -78,13 +78,13 @@ public class TrioTest {
    
    @Test public void equals() {
       assertTrue(t.equals(t));
-      assertTrue(t.equals(Trio.create("a", 1, 42.0)));
-      assertTrue(t.equals(Quartet.create("XYZ", "a", 1, 42.0).removeFirst()));
-      assertTrue(t.equals(Pair.create(1, 42.0).insertFirst("a")));
+      assertTrue(t.equals(Triple.of("a", 1, 42.0)));
+      assertTrue(t.equals(Quadruple.of("XYZ", "a", 1, 42.0).removeFirst()));
+      assertTrue(t.equals(Pair.of(1, 42.0).insertFirst("a")));
       assertFalse(t.equals(Empty.INSTANCE));
-      assertFalse(t.equals(Unit.create("a")));
-      assertFalse(t.equals(Pair.create("a", 1)));
-      assertFalse(t.equals(Trio.create("a", 1, 43.43)));
+      assertFalse(t.equals(Single.of("a")));
+      assertFalse(t.equals(Pair.of("a", 1)));
+      assertFalse(t.equals(Triple.of("a", 1, 43.43)));
       assertFalse(t.equals(Arrays.<Object>asList("a", 1, 42.0)));
    }
    
@@ -101,18 +101,18 @@ public class TrioTest {
    }
    
    @Test public void addAndInsert() {
-      Quartet<String, Integer, Double, String> q = t.add("foobar");
-      assertEquals(Quartet.create("a", 1, 42.0, "foobar"), q);
+      Quadruple<String, Integer, Double, String> q = t.add("foobar");
+      assertEquals(Quadruple.of("a", 1, 42.0, "foobar"), q);
       assertEquals(q, t.insertFourth("foobar"));
-      assertEquals(Quartet.create("foobar", "a", 1, 42.0), t.insertFirst("foobar"));
-      assertEquals(Quartet.create("a", "foobar", 1, 42.0), t.insertSecond("foobar"));
-      assertEquals(Quartet.create("a", 1, "foobar", 42.0), t.insertThird("foobar"));
+      assertEquals(Quadruple.of("foobar", "a", 1, 42.0), t.insertFirst("foobar"));
+      assertEquals(Quadruple.of("a", "foobar", 1, 42.0), t.insertSecond("foobar"));
+      assertEquals(Quadruple.of("a", 1, "foobar", 42.0), t.insertThird("foobar"));
    }
    
    @Test public void remove() {
-      assertEquals(Pair.create(1, 42.0), t.removeFirst());
-      assertEquals(Pair.create("a", 42.0), t.removeSecond());
-      assertEquals(Pair.create("a", 1), t.removeThird());
+      assertEquals(Pair.of(1, 42.0), t.removeFirst());
+      assertEquals(Pair.of("a", 42.0), t.removeSecond());
+      assertEquals(Pair.of("a", 1), t.removeThird());
    }
    
    @Test public void transform() {
@@ -122,10 +122,10 @@ public class TrioTest {
          }
       };
       
-      assertEquals(Trio.create("abcdefg", "abcdefg", "abcdefg"), t.transformAll(f));
-      assertEquals(Trio.create("abcdefg", 1, 42.0), t.transformFirst(f));
-      assertEquals(Trio.create("a", "abcdefg", 42.0), t.transformSecond(f));
-      assertEquals(Trio.create("a", 1, "abcdefg"), t.transformThird(f));
+      assertEquals(Triple.of("abcdefg", "abcdefg", "abcdefg"), t.transformAll(f));
+      assertEquals(Triple.of("abcdefg", 1, 42.0), t.transformFirst(f));
+      assertEquals(Triple.of("a", "abcdefg", 42.0), t.transformSecond(f));
+      assertEquals(Triple.of("a", 1, "abcdefg"), t.transformThird(f));
    }
    
    // serialization
@@ -134,7 +134,7 @@ public class TrioTest {
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       new ObjectOutputStream(bos).writeObject(t);
       ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
-      Trio<?, ?, ?> deserialized = (Trio<?, ?, ?>) new ObjectInputStream(bis).readObject();
+      Triple<?, ?, ?> deserialized = (Triple<?, ?, ?>) new ObjectInputStream(bis).readObject();
       
       assertEquals(t, deserialized);
    }
@@ -143,44 +143,44 @@ public class TrioTest {
    
    @Test public void separate() {
       assertEquals(
-            Trio.create(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
-            Trio.separate(Collections.<Trio<Integer, String, Double>>emptyList()));
+            Triple.of(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+            Triple.separate(Collections.<Triple<Integer, String, Double>>emptyList()));
 
-      List<Trio<Integer, String, Double>> trios = Arrays.asList(Trio.create(1, "a", 101.0),
-            Trio.create(2, "b", 222.0), Trio.create(3, "c", 330.3));
+      List<Triple<Integer, String, Double>> trios = Arrays.asList(Triple.of(1, "a", 101.0),
+            Triple.of(2, "b", 222.0), Triple.of(3, "c", 330.3));
       assertEquals(
-            Trio.create(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
+            Triple.of(Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
                   Arrays.asList(101.0, 222.0, 330.3)),
-            Trio.separate(trios));
+            Triple.separate(trios));
    }
 
-   private <A, B, C> void assertCombinedEquals(List<Trio<A, B, C>> expectedTrios,
+   private <A, B, C> void assertCombinedEquals(List<Triple<A, B, C>> expectedTrios,
          Collection<? extends A> a, Collection<? extends B> b, Collection<? extends C> c) {
-      assertEquals(expectedTrios, Trio.combine(a, b, c));
-      assertEquals(expectedTrios, Trio.combine(Trio.create(a, b, c)));
+      assertEquals(expectedTrios, Triple.combine(a, b, c));
+      assertEquals(expectedTrios, Triple.combine(Triple.of(a, b, c)));
    }
    
    @Test public void combine() {
-      assertCombinedEquals(Collections.<Trio<Integer, String, Double>>emptyList(),
+      assertCombinedEquals(Collections.<Triple<Integer, String, Double>>emptyList(),
             Collections.<Integer>emptyList(), Collections.<String>emptyList(),
             Collections.<Double>emptyList());
 
       assertCombinedEquals(
-            Arrays.asList(Trio.create(1, "a", 101.0), Trio.create(2, "b", 222.0),
-                  Trio.create(3, "c", 330.3)),
+            Arrays.asList(Triple.of(1, "a", 101.0), Triple.of(2, "b", 222.0),
+                  Triple.of(3, "c", 330.3)),
             Arrays.asList(1, 2, 3), Arrays.asList("a", "b", "c"),
             Arrays.asList(101.0, 222.0, 330.3));
    }
 
    private void assertCombineFails(Collection<?> a, Collection<?> b, Collection<?> c) {
       try {
-         Trio.combine(a, b, c);
+         Triple.combine(a, b, c);
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }
 
       try {
-         Trio.combine(Trio.create(a, b, c));
+         Triple.combine(Triple.of(a, b, c));
          fail("expecting IllegalArgumentException but never thrown");
       } catch (IllegalArgumentException expected) {
       }

--- a/test/com/bluegosling/tuples/TuplesTest.java
+++ b/test/com/bluegosling/tuples/TuplesTest.java
@@ -22,19 +22,19 @@ public class TuplesTest {
    }
 
    @Test public void unit() {
-      Unit<String> u = Unit.create("a");
+      Single<String> u = Single.of("a");
       
       Tuple t = Tuples.fromArray("a");
-      assertSame(Unit.class, t.getClass());
+      assertSame(Single.class, t.getClass());
       assertEquals(u, t);
       
       t = Tuples.fromCollection(Collections.singleton("a"));
-      assertSame(Unit.class, t.getClass());
+      assertSame(Single.class, t.getClass());
       assertEquals(u, t);
    }
 
    @Test public void pair() {
-      Pair<String, Integer> p = Pair.create("a", 1);
+      Pair<String, Integer> p = Pair.of("a", 1);
 
       Tuple t = Tuples.fromArray("a", 1);
       assertSame(Pair.class, t.getClass());
@@ -46,39 +46,39 @@ public class TuplesTest {
    }
 
    @Test public void trio() {
-      Trio<String, Integer, Double> trio = Trio.create("a", 1, 42.0);
+      Triple<String, Integer, Double> trio = Triple.of("a", 1, 42.0);
       
       Tuple t = Tuples.fromArray("a", 1, 42.0);
-      assertSame(Trio.class, t.getClass());
+      assertSame(Triple.class, t.getClass());
       assertEquals(trio, t);
       
       t = Tuples.fromCollection(Arrays.<Object>asList("a", 1, 42.0));
-      assertSame(Trio.class, t.getClass());
+      assertSame(Triple.class, t.getClass());
       assertEquals(trio, t);
    }
 
    @Test public void quartet() {
-      Quartet<String, Integer, Double, String> q = Quartet.create("a", 1, 42.0, "foobar");
+      Quadruple<String, Integer, Double, String> q = Quadruple.of("a", 1, 42.0, "foobar");
       
       Tuple t = Tuples.fromArray("a", 1, 42.0, "foobar");
-      assertSame(Quartet.class, t.getClass());
+      assertSame(Quadruple.class, t.getClass());
       assertEquals(q, t);
       
       t = Tuples.fromCollection(Arrays.<Object>asList("a", 1, 42.0, "foobar"));
-      assertSame(Quartet.class, t.getClass());
+      assertSame(Quadruple.class, t.getClass());
       assertEquals(q, t);
    }
 
    @Test public void quintet() {
-      Quintet<String, Integer, Double, String, Long> q =
-            Quintet.create("a", 1, 42.0, "foobar", 0x1234L);
+      Quintuple<String, Integer, Double, String, Long> q =
+            Quintuple.of("a", 1, 42.0, "foobar", 0x1234L);
       
       Tuple t = Tuples.fromArray("a", 1, 42.0, "foobar", 0x1234L);
-      assertSame(Quintet.class, t.getClass());
+      assertSame(Quintuple.class, t.getClass());
       assertEquals(q, t);
       
       t = Tuples.fromCollection(Arrays.<Object>asList("a", 1, 42.0, "foobar", 0x1234L));
-      assertSame(Quintet.class, t.getClass());
+      assertSame(Quintuple.class, t.getClass());
       assertEquals(q, t);
    }
 


### PR DESCRIPTION
Previous names were not correct for tuples:
1. `Unit` is typically the name of an empty tuple, not a singleton tuple. Changed to `Single`.
2. The other names -- `Trio`, `Quartet` and `Quintet` -- are technically correct. But the names ending with "uple" are more intuitive for a package named "tuples". So they were renamed to `Triple`, `Quadruple`, and `Quintuple`.
3. Renamed the static `create` methods to `of` for readability, e.g. `Pair.of("foo", 42)`.
