### PR TITLE
javadoc fixes

### DIFF
--- a/src/com/bluegosling/collections/bits/package-info.java
+++ b/src/com/bluegosling/collections/bits/package-info.java
@@ -1,6 +1,8 @@
 /**
- * This package contains an alternative to {@link java.util.BitSet} that provides an immutable
- * view of a sequence of bits and includes mechanisms to navigate the sequence in arbitrarily-sized
- * chunks of bits.
+ * This package contains an alternative to the standard {@link java.util.BitSet} that provides an
+ * immutable view of a sequence of bits and includes mechanisms to navigate the sequence in
+ * arbitrarily-sized chunks of bits.
+ * 
+ * @see com.bluegosling.collections.bits.BitSequence
  */
 package com.bluegosling.collections.bits;

--- a/src/com/bluegosling/collections/package-info.java
+++ b/src/com/bluegosling/collections/package-info.java
@@ -78,36 +78,6 @@
  * is much narrower than existing JCF types used as stacks like {@link java.util.Deque} and
  * {@link java.util.List}.</li>
  * </ul>
- * </dd>
- * </dl>
- * 
- * 
- * 
- * 
- * 
- * 
- * <p>In addition to new implementations for standard collection interfaces, this package also
- * contains some new collection interfaces:
- * <dl>
- * <dt>{@link com.bluegosling.collections.lists.AssociativeList}</dt>
- *    <dd>A {@link java.util.List} that supports sparse associative keys and can be viewed as a
- *    {@link java.util.Map}.</dd>
- * <dt>{@link com.bluegosling.collections.sets.RandomAccessSet}</dt>
- *    <dd>A {@link java.util.Set} that supports random access of elements and can be viewed as a
- *    {@link java.util.List}.</dd>
- * <dt>{@link com.bluegosling.collections.maps.RandomAccessNavigableMap}</dt>
- *    <dd>A {@link java.util.NavigableMap} that supports random access of elements via key- and
- *    entry-sets that are {@link com.bluegosling.collections.sets.RandomAccessSet}s and a view of values as a
- *    {@link java.util.List}.</dd>
- * <dt>{@link com.bluegosling.collections.bits.BitSequence}</dt>
- *    <dd>An immutable sequence of bits. This is similar to {@link java.util.BitSet} except that it
- *    is immutable and provides additional methods for simpler querying.</dd>
- * <dt>{@link com.bluegosling.collections.queues.PriorityQueue}</dt>
- *    <dd>A priority queue. This interface is a little different than the JRE's class of the same
- *    name in that it exposes additional operations of a classical priority-queue ADT, mainly
- *    {@code reduce-key}. This decouples an element's priority from its intrinsic value, making it
- *    more useful for certain types of graph algorithms.</dd>
- * </dl>
  * 
  * @author Joshua Humphries (jhumphries131@gmail.com)
  */

--- a/src/com/bluegosling/collections/queues/package-info.java
+++ b/src/com/bluegosling/collections/queues/package-info.java
@@ -1,5 +1,11 @@
 /**
  * New interfaces and implementations related to the standard Java {@link java.util.Queue}
  * interface.
+ * 
+ * <p>This package also includes a new related-but-different interface named
+ * {@link com.bluegosling.collections.queues.PriorityQueue}. This interface is quite different from
+ * the JRE's class of the same name in that it exposes additional operations of a classical
+ * priority-queue ADT, mainly {@code reduce-key}. This decouples an element's priority from its
+ * intrinsic value, making it more useful for certain types of graph algorithms.  
  */
 package com.bluegosling.collections.queues;


### PR DESCRIPTION
Fix javadoc errors in collections `package-info.java` (due to junk accidentally left there from earlier branch)