### PR TITLE
Changes in apt.reflect

### DIFF
--- a/src/com/bluegosling/apt/reflect/ArAbstractMember.java
+++ b/src/com/bluegosling/apt/reflect/ArAbstractMember.java
@@ -36,7 +36,7 @@ abstract class ArAbstractMember<E extends Element> extends ArAbstractAnnotatedEl
 
    @Override
    public EnumSet<ArModifier> getModifiers() {
-      return ArModifier.fromElementModifiers(asElement().getModifiers());
+      return ArModifier.fromElementModifiersWithVisibility(asElement().getModifiers());
    }
 
    @Override

--- a/src/com/bluegosling/apt/reflect/ArClass.java
+++ b/src/com/bluegosling/apt/reflect/ArClass.java
@@ -2022,7 +2022,7 @@ public abstract class ArClass implements ArAnnotatedElement, ArGenericDeclaratio
 
       @Override
       public EnumSet<ArModifier> getModifiers() {
-         return ArModifier.fromElementModifiers(asElement().getModifiers());
+         return ArModifier.fromElementModifiersWithVisibility(asElement().getModifiers());
       }
 
       @Override

--- a/src/com/bluegosling/apt/reflect/ArModifier.java
+++ b/src/com/bluegosling/apt/reflect/ArModifier.java
@@ -231,7 +231,7 @@ public enum ArModifier {
       return ret;
    }
    
-   // TODO(jh): doc
+   // TODO: doc
    public static EnumSet<ArModifier> fromBitFieldWithVisibility(int modifiers) {
       EnumSet<ArModifier> ret = fromBitfield(modifiers);
       if (!ret.contains(ArModifier.PUBLIC) && !ret.contains(ArModifier.PROTECTED)
@@ -259,7 +259,7 @@ public enum ArModifier {
       return ret;
    }
 
-   // TODO(jh): doc
+   // TODO: doc
    public static EnumSet<ArModifier> fromElementModifiersWithVisibility(
          Set<javax.lang.model.element.Modifier> mods) {
       EnumSet<ArModifier> ret = fromElementModifiers(mods);

--- a/src/com/bluegosling/apt/reflect/ArParameter.java
+++ b/src/com/bluegosling/apt/reflect/ArParameter.java
@@ -1,6 +1,7 @@
 package com.bluegosling.apt.reflect;
 
 import java.lang.reflect.Parameter;
+import java.util.EnumSet;
 
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -91,11 +92,6 @@ public class ArParameter<M extends ArExecutableMember>
       return param;
    }
 
-   @Override
-   public VariableElement asElement() {
-      return (VariableElement) super.asElement();
-   }
-   
    /**
     * Returns the parameter name.
     * 
@@ -104,7 +100,20 @@ public class ArParameter<M extends ArExecutableMember>
    public String getName() {
       return asElement().getSimpleName().toString();
    }
-   
+
+   /**
+    * Returns the modifiers that apply to this member. Intentionally unlike 
+    * {@link Parameter#getModifiers()}, this returns a set of modifiers (defined in an
+    * {@linkplain ArModifier enum}) instead of a bitmasked integer.
+    * 
+    * @return the modifiers for this member
+    * 
+    * @see Parameter#getModifiers()
+    */
+   public EnumSet<ArModifier> getModifiers() {
+      return ArModifier.fromElementModifiers(asElement().getModifiers());
+   }
+
    /**
     * Returns the type of this parameter. This is a raw type with generic type information erased.
     * For full generic type information, use {@link #getGenericType()}.

--- a/src/com/bluegosling/apt/testing/CompilationContext.java
+++ b/src/com/bluegosling/apt/testing/CompilationContext.java
@@ -201,7 +201,6 @@ public class CompilationContext {
    }
 
    private class TaskBuilderImpl implements TaskBuilderWithProcessor {
-
       private final List<String> options = new ArrayList<>();
       private final Set<Class<?>> classesToProcess = new HashSet<>();
       private final Set<JavaFileObject> filesToProcess = new HashSet<>();
@@ -250,8 +249,12 @@ public class CompilationContext {
       }
 
       private boolean run(Processor processor) throws Throwable {
-         Set<String> classNames =
-               classesToProcess.stream().map(Class::getCanonicalName)
+         // if no classes or files specified, just use Object as a dummy class to process
+         // (just to get us into a processing environment)
+         Set<String> classNames = classesToProcess.isEmpty() && filesToProcess.isEmpty()
+               ? new LinkedHashSet<>(Arrays.asList(Object.class.getCanonicalName()))
+               : classesToProcess.stream()
+                     .map(Class::getCanonicalName)
                      .collect(Collectors.toCollection(LinkedHashSet::new));
          JavaCompiler.CompilationTask task =
                compiler.getTask(null, fileManager, diagnosticCollector.getListener(), options,

--- a/src/com/bluegosling/collections/MoreSpliterators.java
+++ b/src/com/bluegosling/collections/MoreSpliterators.java
@@ -904,7 +904,7 @@ public final class MoreSpliterators {
          if (p == null) {
             return null;
          }
-         // TODO(jh): dynamically sub in a Set instead of array if depth is high
+         // TODO: dynamically sub in a Set instead of array if depth is high
          @SuppressWarnings("unchecked") // generic array creation
          ForkingSpliterator<T>[] ret =
                (ForkingSpliterator<T>[]) new ForkingSpliterator<?>[parent.depth];

--- a/src/com/bluegosling/reflect/model/CoreReflectionElements.java
+++ b/src/com/bluegosling/reflect/model/CoreReflectionElements.java
@@ -982,6 +982,9 @@ enum CoreReflectionElements implements Elements {
 
    @Override
    public TypeElement getTypeElement(Class<?> clazz) {
+      if (clazz.isSynthetic()) {
+         throw new IllegalArgumentException("Synthetic types are not valid elements");
+      }
       return new CoreReflectionTypeElement(clazz);
    }
 
@@ -992,16 +995,27 @@ enum CoreReflectionElements implements Elements {
 
    @Override
    public VariableElement getParameterElement(Parameter parameter) {
+      if (parameter.isSynthetic()) {
+         throw new IllegalArgumentException("Synthetic parameters are not valid elements");
+      }
       return new CoreReflectionParameterElement(parameter);
    }
 
    @Override
    public VariableElement getFieldElement(Field field) {
+      if (field.isSynthetic()) {
+         throw new IllegalArgumentException("Synthetic fields are not valid elements");
+      }
       return new CoreReflectionFieldElement(field);
    }
 
    @Override
    public ExecutableElement getExecutableElement(Executable executable) {
+      if (executable.isSynthetic()
+            || (executable instanceof Method && ((Method) executable).isBridge())) {
+         throw new IllegalArgumentException(
+               "Synthetic and bridge methods and constructors are not valid elements");
+      }
       return new CoreReflectionExecutableElement(executable);
    }
 

--- a/src/com/bluegosling/reflect/model/CoreReflectionExecutableElement.java
+++ b/src/com/bluegosling/reflect/model/CoreReflectionExecutableElement.java
@@ -93,7 +93,9 @@ implements ExecutableElement {
       Parameter[] params = base().getParameters();
       List<VariableElement> result = new ArrayList<>(params.length);
       for (Parameter param : params) {
-         result.add(CoreReflectionElements.INSTANCE.getParameterElement(param));
+         if (!param.isSynthetic()) {
+            result.add(CoreReflectionElements.INSTANCE.getParameterElement(param));
+         }
       }
       return result;
    }

--- a/src/com/bluegosling/reflect/model/CoreReflectionPackages.java
+++ b/src/com/bluegosling/reflect/model/CoreReflectionPackages.java
@@ -52,7 +52,8 @@ final class CoreReflectionPackages {
          } catch (ClassNotFoundException | LinkageError e) {
             continue; // skip unloadable entries
          }
-         if (!cl.isAnonymousClass() && !cl.isLocalClass() && !cl.isMemberClass()) {
+         if (!cl.isSynthetic() && !cl.isAnonymousClass() && !cl.isLocalClass()
+               && !cl.isMemberClass()) {
             results.add(new CoreReflectionTypeElement(cl));
          }
       }

--- a/src/com/bluegosling/reflect/model/CoreReflectionTypeElement.java
+++ b/src/com/bluegosling/reflect/model/CoreReflectionTypeElement.java
@@ -84,15 +84,27 @@ class CoreReflectionTypeElement extends CoreReflectionBaseElement<Class<?>> impl
       List<Element> result =
             new ArrayList<>(fields.length + ctors.length + methods.length + classes.length);
       for (Field f : fields) {
+         if (f.isSynthetic()) {
+            continue;
+         }
          result.add(CoreReflectionElements.INSTANCE.getFieldElement(f));
       }
       for (Constructor<?> c : ctors) {
+         if (c.isSynthetic()) {
+            continue;
+         }
          result.add(CoreReflectionElements.INSTANCE.getExecutableElement(c));
       }
       for (Method m : methods) {
+         if (m.isSynthetic() || m.isBridge()) {
+            continue;
+         }
          result.add(CoreReflectionElements.INSTANCE.getExecutableElement(m));
       }
       for (Class<?> c : classes) {
+         if (c.isSynthetic()) {
+            continue;
+         }
          result.add(CoreReflectionElements.INSTANCE.getTypeElement(c));
       }
       return result;

--- a/test/com/bluegosling/apt/reflect/ArClassTest.java
+++ b/test/com/bluegosling/apt/reflect/ArClassTest.java
@@ -1,0 +1,162 @@
+package com.bluegosling.apt.reflect;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.bluegosling.apt.ProcessingEnvironments;
+import com.bluegosling.apt.testing.CompilationContext;
+import com.bluegosling.apt.testing.TestEnvironment;
+import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ArClassTest {
+   // List of classes, for comparing behavior of ArClass to java.lang.Class
+   private static final List<Class<?>> CLASSES_TO_TEST;
+   static {
+      Class<?>[] nonArrayTypes = new Class<?>[] { Object.class, Class.class,
+         Map.class, Map.Entry.class, ArrayList.class, Repeatable.class, Target.class,
+         ElementType.class, RetentionPolicy.class, CompilationContext.TaskBuilder.class, void.class,
+         boolean.class, byte.class, char.class, short.class, int.class, long.class, float.class,
+         double.class };
+      List<Class<?>> classesToTest = new ArrayList<>(nonArrayTypes.length * 5);
+      for (Class<?> clazz : nonArrayTypes) {
+         for (int i = 0; i < 5; i++) {
+            classesToTest.add(clazz);
+            if (clazz == void.class) {
+               break;
+            }
+            clazz = Array.newInstance(clazz, 0).getClass();
+         }
+      }
+      CLASSES_TO_TEST = Collections.unmodifiableList(classesToTest);
+   }
+   
+   @Test public void getCanonicalName() throws Exception {
+      check(Class::getCanonicalName, ArClass::getCanonicalName);
+   }
+
+   @Test public void getName() throws Exception {
+      check(Class::getName, ArClass::getName);
+   }
+
+   @Test public void getSimpleName() throws Exception {
+      check(Class::getSimpleName, ArClass::getSimpleName);
+   }
+
+   @Test public void isInterface() throws Exception {
+      check(Class::isInterface, ArClass::isInterface);
+   }
+
+   @Test public void isEnum() throws Exception {
+      check(Class::isEnum, ArClass::isEnum);
+   }
+
+   @Test public void isAnnotation() throws Exception {
+      check(Class::isAnnotation, ArClass::isAnnotation);
+   }
+
+   @Test public void isArray() throws Exception {
+      check(Class::isArray, ArClass::isArray);
+   }
+
+   @Test public void isPrimitive() throws Exception {
+      check(Class::isPrimitive, ArClass::isPrimitive);
+   }
+
+   @Test public void isMemberClass() throws Exception {
+      check(Class::isMemberClass, ArClass::isMemberClass);
+   }
+
+   @Test public void getModifiers() throws Exception {
+      check(Arrays.asList(PrivateFinal.class, ProtectedFinal.class, PublicFinal.class,
+            StaticAbstract.class), Class::getModifiers,
+            arc -> ArModifier.toBitfield(arc.getModifiers()));
+      run(env -> assertTrue(ArClass.forClass(StaticAbstract.class).getModifiers()
+            .contains(ArModifier.PACKAGE_PRIVATE)));
+   }
+
+   @Test public void isAnonymousClass() throws Exception {
+      check(Class::isAnonymousClass, ArClass::isAnonymousClass);
+      // None of these are anonymous classes. It isn't actually possible for an annotation
+      // processor to get a local or anonymous class! (So it is strange that the API surface
+      // area would make one expect it's possible -- since you can get a type element's nesting
+      // kind which ostensibly could be anonymous or local.)
+      // See https://bugs.openjdk.java.net/browse/JDK-6587158
+   }
+
+   @Test public void isLocalClass() throws Exception {
+      check(Class::isLocalClass, ArClass::isLocalClass);
+      // None of these are local classes. It isn't actually possible for an annotation processor to
+      // get a local or anonymous class! (So it is strange that the API surface area would make one
+      // expect it's possible -- since you can get a type element's nesting kind which ostensibly
+      // could be anonymous or local.)
+      // See https://bugs.openjdk.java.net/browse/JDK-6587158
+   }
+
+   private <T> void check(Function<Class<?>, T> classExtract, Function<ArClass, T> arClassExtract)
+         throws Exception {
+      check(CLASSES_TO_TEST, classExtract, arClassExtract);
+   }
+   
+   private <T> void check(List<Class<?>> classesToTest, Function<Class<?>, T> classExtract,
+         Function<ArClass, T> arClassExtract) throws Exception {
+      run(env -> {
+         for (Class<?> clazz : classesToTest) {
+            checkClass(clazz, classExtract, arClassExtract);
+         }
+      });
+   }
+   
+   private <T> void checkClass(Class<?> clazz, Function<Class<?>, T> classExtract,
+         Function<ArClass, T> arClassExtract) throws ClassNotFoundException {
+      ArClass arClass = ArClass.forClass(clazz);
+      T t1 = classExtract.apply(clazz);
+      T t2 = arClassExtract.apply(arClass);
+      assertEquals(t1, t2);
+   }
+   
+   private interface Task {
+      void run(TestEnvironment env) throws Exception;
+   }
+   
+   private void run(Task task) {
+      try {
+         new CompilationContext().newTask().run(env -> {
+            ProcessingEnvironments.setup(env.processingEnvironment());
+            try {
+               task.run(env);
+            } finally {
+               ProcessingEnvironments.reset();
+            }
+            return null;
+         });
+      } catch (RuntimeException | Error e) {
+         throw e;
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+   
+   public final class PublicFinal {
+   }
+
+   protected final class ProtectedFinal {
+   }
+
+   private final class PrivateFinal {
+   }
+   
+   static abstract class StaticAbstract {
+   }
+}


### PR DESCRIPTION
* Making modifiers work as expected (in particular, for pseudo-modifier of `PACKAGE_PRIVATE`)
* Add first test for `apt.reflect` package
* Ignore synthetic and bridge elements in `reflect.model` package
* minor: remove "jh" from TODO comments